### PR TITLE
feat: simplify chat to channel-voice only

### DIFF
--- a/__tests__/commands/slash/ChatCommand.test.js
+++ b/__tests__/commands/slash/ChatCommand.test.js
@@ -1,5 +1,5 @@
 // __tests__/commands/slash/ChatCommand.test.js
-// Tests for ChatSlashCommand - prompt display in responses
+// Tests for ChatSlashCommand - channel-voice default, simplified response format
 
 // Mock the logger
 jest.mock('../../../logger', () => ({
@@ -9,22 +9,22 @@ jest.mock('../../../logger', () => ({
   warn: jest.fn()
 }));
 
-// Mock personalities
+// Mock personalities - only channel-voice matters now
 jest.mock('../../../personalities', () => ({
   get: jest.fn((id) => {
     const personalities = {
-      'friendly': {
-        id: 'friendly',
-        name: 'Friendly Assistant',
-        emoji: '😊',
-        description: 'A friendly assistant',
-        systemPrompt: 'You are a friendly assistant.'
+      'channel-voice': {
+        id: 'channel-voice',
+        name: 'Channel Voice',
+        emoji: '🗣️',
+        description: 'Learned group communication style',
+        systemPrompt: 'You speak in the style of the group.'
       }
     };
     return personalities[id] || null;
   }),
   list: jest.fn(() => [
-    { id: 'friendly', name: 'Friendly Assistant', emoji: '😊', description: 'A friendly assistant' }
+    { id: 'channel-voice', name: 'Channel Voice', emoji: '🗣️', description: 'Learned group communication style' }
   ])
 }));
 
@@ -48,9 +48,9 @@ describe('ChatSlashCommand', () => {
         success: true,
         message: 'Hello! How can I help you today?',
         personality: {
-          id: 'friendly',
-          name: 'Friendly Assistant',
-          emoji: '😊'
+          id: 'channel-voice',
+          name: 'Channel Voice',
+          emoji: '🗣️'
         },
         tokens: { input: 100, output: 50, total: 150 }
       })
@@ -63,7 +63,6 @@ describe('ChatSlashCommand', () => {
       options: {
         getString: jest.fn((name) => {
           if (name === 'message') return 'What is the meaning of life?';
-          if (name === 'personality') return 'friendly';
           return null;
         }),
         getAttachment: jest.fn().mockReturnValue(null),
@@ -80,7 +79,46 @@ describe('ChatSlashCommand', () => {
     command = new ChatSlashCommand(mockChatService);
   });
 
+  describe('constructor', () => {
+    it('should not have a personality option', () => {
+      const options = command.data.options;
+      const personalityOption = options.find(o => o.name === 'personality');
+      expect(personalityOption).toBeUndefined();
+    });
+
+    it('should not have an uncensored option', () => {
+      const options = command.data.options;
+      const uncensoredOption = options.find(o => o.name === 'uncensored');
+      expect(uncensoredOption).toBeUndefined();
+    });
+
+    it('should have a message option', () => {
+      const options = command.data.options;
+      const messageOption = options.find(o => o.name === 'message');
+      expect(messageOption).toBeDefined();
+    });
+
+    it('should have an image option', () => {
+      const options = command.data.options;
+      const imageOption = options.find(o => o.name === 'image');
+      expect(imageOption).toBeDefined();
+    });
+  });
+
   describe('execute', () => {
+    it('should always use channel-voice personality', async () => {
+      await command.execute(mockInteraction, {});
+
+      expect(mockChatService.chat).toHaveBeenCalledWith(
+        'channel-voice',
+        'What is the meaning of life?',
+        expect.any(Object),
+        'channel123',
+        'guild456',
+        null
+      );
+    });
+
     it('should include user prompt in response', async () => {
       await command.execute(mockInteraction, {});
 
@@ -91,28 +129,25 @@ describe('ChatSlashCommand', () => {
       );
     });
 
-    it('should include personality header after prompt', async () => {
-      await command.execute(mockInteraction, {});
-
-      const response = mockInteraction.editReply.mock.calls[0][0].content;
-      expect(response).toContain('**Prompt:**');
-      expect(response).toContain('😊 **Friendly Assistant**');
-    });
-
-    it('should show prompt before personality response', async () => {
-      await command.execute(mockInteraction, {});
-
-      const response = mockInteraction.editReply.mock.calls[0][0].content;
-      const promptIndex = response.indexOf('**Prompt:**');
-      const personalityIndex = response.indexOf('😊 **Friendly Assistant**');
-      expect(promptIndex).toBeLessThan(personalityIndex);
-    });
-
     it('should include the AI response message', async () => {
       await command.execute(mockInteraction, {});
 
       const response = mockInteraction.editReply.mock.calls[0][0].content;
       expect(response).toContain('Hello! How can I help you today?');
+    });
+
+    it('should not include personality emoji/name header in response', async () => {
+      await command.execute(mockInteraction, {});
+
+      const response = mockInteraction.editReply.mock.calls[0][0].content;
+      expect(response).not.toContain('🗣️ **Channel Voice**');
+    });
+
+    it('should format response as prompt then message only', async () => {
+      await command.execute(mockInteraction, {});
+
+      const response = mockInteraction.editReply.mock.calls[0][0].content;
+      expect(response).toBe('**Prompt:** What is the meaning of life?\n\nHello! How can I help you today?');
     });
 
     it('should not include prompt line in error responses', async () => {

--- a/commands/slash/ChatCommand.js
+++ b/commands/slash/ChatCommand.js
@@ -1,48 +1,25 @@
 // commands/slash/ChatCommand.js
-// Slash command for chatting with AI personalities
+// Slash command for chatting with the bot using channel voice personality
 
 const { SlashCommandBuilder, AttachmentBuilder } = require('discord.js');
 const BaseSlashCommand = require('../base/BaseSlashCommand');
 const TextUtils = require('../../utils/textUtils');
 const logger = require('../../logger');
-const personalityManager = require('../../personalities');
-const localLlmService = require('../../services/LocalLlmService');
 
 class ChatSlashCommand extends BaseSlashCommand {
   constructor(chatService) {
-    // Build personality choices dynamically
-    const personalities = personalityManager.list();
-    const choices = personalities.slice(0, 25).map(p => ({
-      name: `${p.emoji} ${p.name}`,
-      value: p.id
-    }));
-
     super({
       data: new SlashCommandBuilder()
         .setName('chat')
-        .setDescription('Chat with an AI personality')
+        .setDescription('Chat with the bot')
         .addStringOption(option =>
           option.setName('message')
-            .setDescription('Your message to the personality')
+            .setDescription('Your message')
             .setRequired(true)
             .setMaxLength(2000))
-        .addStringOption(option => {
-          option.setName('personality')
-            .setDescription('Which personality to chat with (default: uncensored if available, otherwise friendly)')
-            .setRequired(false);
-          // Add choices if we have them
-          if (choices.length > 0) {
-            option.addChoices(...choices);
-          }
-          return option;
-        })
         .addAttachmentOption(option =>
           option.setName('image')
             .setDescription('Optional image to include in the conversation')
-            .setRequired(false))
-        .addBooleanOption(option =>
-          option.setName('uncensored')
-            .setDescription('Use local LLM for less restricted responses (if enabled)')
             .setRequired(false)),
       deferReply: true,
       cooldown: 0
@@ -52,33 +29,13 @@ class ChatSlashCommand extends BaseSlashCommand {
   }
 
   async execute(interaction, context) {
-    // Default to uncensored if local LLM is available, otherwise friendly
-    const defaultPersonality = personalityManager.get('channel-voice')
-      ? 'channel-voice'
-      : personalityManager.get('uncensored') ? 'uncensored' : 'friendly';
-    const personalityId = interaction.options.getString('personality') || defaultPersonality;
+    const personalityId = 'channel-voice';
     const userMessage = interaction.options.getString('message');
     const attachment = interaction.options.getAttachment('image');
-    const useUncensored = interaction.options.getBoolean('uncensored') || false;
     const channelId = interaction.channel.id;
     const guildId = interaction.guild?.id || null;
 
-    this.logExecution(interaction, `personality=${personalityId}${useUncensored ? ' uncensored=true' : ''}`);
-
-    // Check uncensored access if requested
-    if (useUncensored) {
-      const isNsfwChannel = interaction.channel.nsfw || false;
-      const accessCheck = localLlmService.checkUncensoredAccess(
-        channelId,
-        interaction.user.id,
-        isNsfwChannel
-      );
-
-      if (!accessCheck.allowed) {
-        await this.sendError(interaction, accessCheck.reason);
-        return;
-      }
-    }
+    this.logExecution(interaction, `message="${userMessage.substring(0, 50)}"`);
 
     // Get image URL if attachment provided
     let imageUrl = null;
@@ -92,27 +49,17 @@ class ChatSlashCommand extends BaseSlashCommand {
       }
     }
 
-    // Call chat service
+    // Call chat service with channel-voice personality
     const result = await this.chatService.chat(
       personalityId,
       userMessage,
       interaction.user,
       channelId,
       guildId,
-      imageUrl,
-      { useUncensored }
+      imageUrl
     );
 
     if (!result.success) {
-      if (result.availablePersonalities) {
-        const availableList = result.availablePersonalities
-          .map(p => `\`${p.id}\` - ${p.emoji} ${p.name}`)
-          .join('\n');
-        await this.sendReply(interaction, {
-          content: `Unknown personality. Available options:\n${availableList}`
-        });
-        return;
-      }
       // Handle specific error reasons with helpful messages (without "Error: " prefix)
       if (result.reason === 'expired' || result.reason === 'message_limit' || result.reason === 'token_limit') {
         await this.sendReply(interaction, {
@@ -124,18 +71,8 @@ class ChatSlashCommand extends BaseSlashCommand {
       return;
     }
 
-    // Format response with personality header and wrap URLs
-    // Add unlock emoji if local LLM was used (either via uncensored option or uncensored personality)
-    const usedLocalLlm = (useUncensored || personalityId === 'uncensored') && !result.fallback?.occurred;
-    const uncensoredIndicator = usedLocalLlm ? ' \uD83D\uDD13' : '';
-
-    // Add fallback notice if the local LLM was unavailable
-    const fallbackNotice = result.fallback?.occurred
-      ? `\n> *\u26A0\uFE0F Local LLM unavailable \u2014 responded using ${result.personality.emoji} ${result.personality.name} instead*\n`
-      : '';
-
     const response = TextUtils.wrapUrls(
-      `**Prompt:** ${userMessage}\n\n${result.personality.emoji} **${result.personality.name}**${uncensoredIndicator}${fallbackNotice}\n\n${result.message}`
+      `**Prompt:** ${userMessage}\n\n${result.message}`
     );
 
     // Convert any generated images to Discord attachments
@@ -158,7 +95,6 @@ class ChatSlashCommand extends BaseSlashCommand {
 
     // Send response with images if any, handling long messages
     if (imageAttachments.length > 0) {
-      // For messages with images, send text first then images
       await this.sendLongResponse(interaction, response);
       await interaction.followUp({ files: imageAttachments });
     } else {

--- a/commands/slash/ChatListCommand.js
+++ b/commands/slash/ChatListCommand.js
@@ -3,7 +3,6 @@
 
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const BaseSlashCommand = require('../base/BaseSlashCommand');
-const personalityManager = require('../../personalities');
 const logger = require('../../logger');
 
 class ChatListSlashCommand extends BaseSlashCommand {
@@ -41,19 +40,14 @@ class ChatListSlashCommand extends BaseSlashCommand {
       .setColor(0x5865F2);
 
     for (const conv of conversations) {
-      // Use conversation's personality data which includes emoji and name
-      const emoji = conv.personality?.emoji || '🎭';
-      const name = conv.personality?.name || conv.personalityId || 'Unknown';
-      const personalityId = conv.personality?.id || conv.personalityId;
-
       const timeAgo = this.getTimeAgo(new Date(conv.lastActivity));
       const preview = conv.lastUserMessage
         ? `"${conv.lastUserMessage.substring(0, 50)}${conv.lastUserMessage.length > 50 ? '...' : ''}"`
         : '';
 
       embed.addFields({
-        name: `${emoji} ${name} (${conv.status || 'expired'})`,
-        value: `${conv.messageCount || 0} messages • ${timeAgo}\n${preview}\n\`/chatresume personality:${personalityId}\``,
+        name: `💬 Conversation (${conv.status || 'expired'})`,
+        value: `${conv.messageCount || 0} messages • ${timeAgo}\n${preview}\nUse \`/chatresume\` to continue`,
         inline: false
       });
     }

--- a/commands/slash/ChatResetCommand.js
+++ b/commands/slash/ChatResetCommand.js
@@ -1,32 +1,16 @@
 // commands/slash/ChatResetCommand.js
-// Admin slash command to reset a personality's conversation history
+// Admin slash command to reset conversation history
 
 const { SlashCommandBuilder } = require('discord.js');
 const BaseSlashCommand = require('../base/BaseSlashCommand');
-const personalityManager = require('../../personalities');
 const logger = require('../../logger');
 
 class ChatResetSlashCommand extends BaseSlashCommand {
   constructor(chatService) {
-    const personalities = personalityManager.list();
-    const choices = personalities.slice(0, 25).map(p => ({
-      name: `${p.emoji} ${p.name}`,
-      value: p.id
-    }));
-
     super({
       data: new SlashCommandBuilder()
         .setName('chatreset')
-        .setDescription('Reset a personality\'s conversation history (admin only)')
-        .addStringOption(option => {
-          option.setName('personality')
-            .setDescription('Which personality to reset')
-            .setRequired(true);
-          if (choices.length > 0) {
-            option.addChoices(...choices);
-          }
-          return option;
-        }),
+        .setDescription('Reset conversation history in this channel (admin only)'),
       adminOnly: true,
       cooldown: 5
     });
@@ -35,23 +19,17 @@ class ChatResetSlashCommand extends BaseSlashCommand {
   }
 
   async execute(interaction, context) {
-    const personalityId = interaction.options.getString('personality');
+    const personalityId = 'channel-voice';
     const channelId = interaction.channel.id;
 
-    this.logExecution(interaction, `personality=${personalityId}`);
-
-    const personality = personalityManager.get(personalityId);
-    if (!personality) {
-      await this.sendError(interaction, 'Unknown personality.');
-      return;
-    }
+    this.logExecution(interaction, `resetting conversation`);
 
     // Correct parameter order: channelId first, then personalityId
     const result = await this.chatService.resetConversation(channelId, personalityId);
 
     if (result.success) {
       await interaction.reply({
-        content: `${personality.emoji} Conversation with **${personality.name}** has been reset. They will have no memory of previous messages.`,
+        content: '✅ Conversation history has been reset. The bot will have no memory of previous messages in this channel.',
         ephemeral: false
       });
     } else {

--- a/commands/slash/ChatResumeCommand.js
+++ b/commands/slash/ChatResumeCommand.js
@@ -4,30 +4,14 @@
 const { SlashCommandBuilder } = require('discord.js');
 const BaseSlashCommand = require('../base/BaseSlashCommand');
 const TextUtils = require('../../utils/textUtils');
-const personalityManager = require('../../personalities');
 const logger = require('../../logger');
 
 class ChatResumeSlashCommand extends BaseSlashCommand {
   constructor(chatService) {
-    const personalities = personalityManager.list();
-    const choices = personalities.slice(0, 25).map(p => ({
-      name: `${p.emoji} ${p.name}`,
-      value: p.id
-    }));
-
     super({
       data: new SlashCommandBuilder()
         .setName('chatresume')
-        .setDescription('Resume an expired conversation with a personality')
-        .addStringOption(option => {
-          option.setName('personality')
-            .setDescription('Which personality to resume')
-            .setRequired(true);
-          if (choices.length > 0) {
-            option.addChoices(...choices);
-          }
-          return option;
-        })
+        .setDescription('Resume an expired conversation')
         .addStringOption(option =>
           option.setName('message')
             .setDescription('Your message to continue the conversation')
@@ -41,12 +25,12 @@ class ChatResumeSlashCommand extends BaseSlashCommand {
   }
 
   async execute(interaction, context) {
-    const personalityId = interaction.options.getString('personality');
+    const personalityId = 'channel-voice';
     const userMessage = interaction.options.getString('message');
     const channelId = interaction.channel.id;
     const guildId = interaction.guild?.id || null;
 
-    this.logExecution(interaction, `personality=${personalityId}`);
+    this.logExecution(interaction, `resuming conversation`);
 
     // Use resumeChat method which handles both restore and chat in one call
     const result = await this.chatService.resumeChat(
@@ -58,21 +42,12 @@ class ChatResumeSlashCommand extends BaseSlashCommand {
     );
 
     if (!result.success) {
-      if (result.availablePersonalities) {
-        const availableList = result.availablePersonalities
-          .map(p => `\`${p.id}\` - ${p.emoji} ${p.name}`)
-          .join('\n');
-        await this.sendReply(interaction, {
-          content: `Unknown personality. Available options:\n${availableList}`
-        });
-        return;
-      }
       await this.sendError(interaction, result.error);
       return;
     }
 
     const response = TextUtils.wrapUrls(
-      `${result.personality.emoji} **${result.personality.name}** *(conversation resumed)*\n\n${result.message}`
+      `*(conversation resumed)*\n\n${result.message}`
     );
 
     await this.sendLongResponse(interaction, response);

--- a/commands/slash/ChatThreadCommand.js
+++ b/commands/slash/ChatThreadCommand.js
@@ -5,35 +5,18 @@ const { SlashCommandBuilder, ChannelType, AttachmentBuilder } = require('discord
 const BaseSlashCommand = require('../base/BaseSlashCommand');
 const TextUtils = require('../../utils/textUtils');
 const logger = require('../../logger');
-const personalityManager = require('../../personalities');
 
 class ChatThreadSlashCommand extends BaseSlashCommand {
   constructor(chatService) {
-    // Build personality choices dynamically
-    const personalities = personalityManager.list();
-    const choices = personalities.slice(0, 25).map(p => ({
-      name: `${p.emoji} ${p.name}`,
-      value: p.id
-    }));
-
     super({
       data: new SlashCommandBuilder()
         .setName('chatthread')
-        .setDescription('Start a dedicated thread for an extended conversation with an AI personality')
+        .setDescription('Start a dedicated thread for an extended conversation')
         .addStringOption(option =>
           option.setName('message')
             .setDescription('Your opening message')
             .setRequired(true)
-            .setMaxLength(2000))
-        .addStringOption(option => {
-          option.setName('personality')
-            .setDescription('Which personality to chat with (default: friendly)')
-            .setRequired(false);
-          if (choices.length > 0) {
-            option.addChoices(...choices);
-          }
-          return option;
-        }),
+            .setMaxLength(2000)),
       deferReply: true,
       cooldown: 10 // Slightly higher cooldown to prevent thread spam
     });
@@ -44,29 +27,17 @@ class ChatThreadSlashCommand extends BaseSlashCommand {
   }
 
   async execute(interaction, context) {
-    const personalityId = interaction.options.getString('personality') || 'friendly';
+    const personalityId = 'channel-voice';
     const userMessage = interaction.options.getString('message');
     const channelId = interaction.channel.id;
     const guildId = interaction.guild?.id || null;
 
-    // Get personality info
-    const personality = personalityManager.get(personalityId);
-    if (!personality) {
-      const available = personalityManager.list()
-        .map(p => `\`${p.id}\` - ${p.emoji} ${p.name}`)
-        .join('\n');
-      await this.sendReply(interaction, {
-        content: `Unknown personality. Available options:\n${available}`
-      });
-      return;
-    }
-
-    this.logExecution(interaction, `personality=${personalityId}, creating thread`);
+    this.logExecution(interaction, `creating thread`);
 
     // Create thread for conversation
     let thread;
     try {
-      const threadName = `${personality.emoji} Chat with ${personality.name}`;
+      const threadName = `💬 Chat: ${userMessage.substring(0, 90)}`;
       thread = await interaction.channel.threads.create({
         name: threadName.substring(0, 100), // Thread names max 100 chars
         autoArchiveDuration: 60, // Archive after 1 hour of inactivity
@@ -93,11 +64,11 @@ class ChatThreadSlashCommand extends BaseSlashCommand {
 
     // Reply to the original interaction
     await this.sendReply(interaction, {
-      content: `Started a conversation with ${personality.emoji} **${personality.name}** in ${thread}!\n\nJust type your messages in the thread - no commands needed.`,
+      content: `Started a conversation in ${thread}!\n\nJust type your messages in the thread - no commands needed.`,
       ephemeral: false
     });
 
-    // Get the initial response from the personality
+    // Get the initial response
     const result = await this.chatService.chat(
       personalityId,
       userMessage,
@@ -117,9 +88,7 @@ class ChatThreadSlashCommand extends BaseSlashCommand {
     }
 
     // Send the response in the thread
-    const response = TextUtils.wrapUrls(
-      `${result.personality.emoji} **${result.personality.name}**\n\n${result.message}`
-    );
+    const response = TextUtils.wrapUrls(result.message);
 
     // Split long messages
     const chunks = this.splitMessage(response, 2000);
@@ -210,9 +179,7 @@ class ChatThreadSlashCommand extends BaseSlashCommand {
       return true;
     }
 
-    const response = TextUtils.wrapUrls(
-      `${result.personality.emoji} **${result.personality.name}**\n\n${result.message}`
-    );
+    const response = TextUtils.wrapUrls(result.message);
 
     // Split long messages
     const chunks = this.splitMessage(response, 2000);

--- a/features.md
+++ b/features.md
@@ -20,33 +20,13 @@
 - **Automatic Polling**: Monitors collection for new links
 - **Multiple Formats**: Supports readable, monolith, and PDF archives
 
-### Personality Chat
-- **7 Built-in Personalities**:
-  - Channel Voice (learned group communication style - **default**)
-  - Friendly Assistant (helpful, informal)
-  - Professor Grimsworth (grumpy historian)
-  - Jack Shadows (noir detective)
-  - Erik the Existentialist (philosopher)
-  - x0r_kid (90s IRC gamer)
-  - Uncensored (enhanced local LLM personality)
-- **Prompt Display**: Responses show the user's original prompt before the AI reply, matching the `/imagine` format
-- **Default Personality**: Just `/chat <message>` defaults to Channel Voice (falls back to Friendly Assistant if voice profile not enabled)
+### Chat
+- **Channel Voice**: Bot uses a learned group communication style as its voice, dynamically generated from IRC history and Discord messages
+- **Simple Interface**: Just `/chat <message>` — no personality picker needed
+- **Prompt Display**: Responses show the user's original prompt before the AI reply
 - **Image Vision**: Attach images to chat messages for analysis and discussion
 - **Web Search**: Bot can search the web for current information when needed
-- **Extensible System**: Add new personalities via `.js` files
-- **Per-user Token Tracking**: Usage recorded per personality
-
-### Uncensored Mode (Local LLM)
-- **Local LLM Support**: Route chat requests to a local Ollama instance for less restricted responses
-- **Opt-in Per Request**: Use `/chat message:... uncensored:true` to enable for that message
-- **Dedicated Personality**: `uncensored` personality defaults to local LLM automatically
-- **Access Controls**: Configurable per-channel, per-user, and NSFW-only restrictions
-- **Personality Variants**: Personalities can define `uncensoredSystemPrompt` for enhanced local mode
-- **Visual Indicator**: Uncensored responses marked with 🔓 emoji
-- **Automatic Fallback**: When local LLM goes down mid-runtime, automatically falls back to cloud provider with the `friendly` personality and notifies the user
-- **Circuit Breaker**: After a connection failure, the local LLM is temporarily marked unavailable (60s cooldown) to avoid repeated timeout delays on subsequent requests
-- **DeepSeek-R1 Support**: Strips thinking tokens (`<think>...</think>`) from reasoning model responses
-- **Response Length Control**: Configurable `maxResponseLength` truncates overly verbose local LLM responses at sentence boundaries
+- **Per-user Token Tracking**: Usage recorded per user
 
 ### Conversation Memory
 - **Channel-Scoped Memory**: All users in a channel share a conversation with each personality

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.7.12",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-article-archiver-bot",
-      "version": "2.7.12",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.7.12",
+  "version": "2.8.0",
   "license": "MIT",
   "description": "A Discord bot that integrates with Linkwarden for self-hosted article archiving and uses OpenAI-compatible APIs to automatically generate summaries of archived articles with support for authenticated/paywalled content.",
   "main": "bot.js",

--- a/users.md
+++ b/users.md
@@ -38,66 +38,34 @@ After the bot summarizes an article, **reply directly** to the summary message t
 
 ---
 
-## Personality Chat
+## Chat
 
-Chat with unique AI personalities for fun, creative conversations. The bot remembers conversation history within each channel.
+Chat with the bot using a voice that reflects the group's communication style. The bot remembers conversation history within each channel.
 
 ### Quick Start
 
-Just type `/chat message:Hello!` to start chatting with the default **Friendly Assistant** personality.
+Just type `/chat message:Hello!` to start chatting.
 
 ### Commands
 
 | Command | Description |
 |---------|-------------|
-| `/chat message:<text>` | Chat with the default personality (Friendly Assistant) |
-| `/chat message:<text> personality:<name>` | Chat with a specific personality |
+| `/chat message:<text>` | Chat with the bot |
 | `/chat message:<text> image:<file>` | Chat about an attached image |
-| `/chat message:<text> uncensored:true` | Route to local LLM for less restricted responses |
 | `/chatthread message:<text>` | Start a dedicated chat thread |
-| `/personalities` | List all available personalities |
 | `/chatlist` | List your resumable conversations |
-| `/chatresume personality:<name> message:<text>` | Resume an expired conversation |
-| `/chatreset personality:<name>` | Reset a conversation (admin only) |
-
-### Reply to Continue
-
-You can **reply directly** to any bot personality message to continue the conversation without using commands. Just use Discord's reply feature.
-
-**Example**:
-1. Use `/chat message:Tell me a story`
-2. The bot responds
-3. Reply to that message with "What happened next?"
-4. The conversation continues naturally
+| `/chatresume message:<text>` | Resume an expired conversation |
+| `/chatreset` | Reset conversation history (admin only) |
 
 ### Conversation Memory
 
-- **Channel-scoped**: Each channel has its own conversation with each personality
-- **Multi-user**: Everyone in the channel shares the same conversation - the personality knows who said what
+- **Channel-scoped**: Each channel has its own conversation history
+- **Multi-user**: Everyone in the channel shares the same conversation - the bot knows who said what
 - **Limits**: Conversations have resource limits:
   - Maximum 100 messages per conversation
   - Maximum 150,000 tokens per conversation
   - Conversations expire after 30 minutes of inactivity
 - **Resume**: Use `/chatresume` to pick up where you left off after expiration
-
-### Available Personalities
-
-| ID | Name | Description |
-|----|------|-------------|
-| `friendly-assistant` | 😊 Friendly Assistant | Helpful, informal assistant for casual chat and questions (**default**) |
-| `grumpy-historian` | 📚 Professor Grimsworth | An irritable history professor who relates everything to obscure historical events |
-| `noir-detective` | 🕵️ Jack Shadows | A hardboiled 1940s detective who narrates everything in classic noir prose |
-| `existential-philosopher` | 🤔 Erik the Existentialist | A philosophy grad student who spirals every topic into questions about meaning |
-| `irc-gamer` | 💾 x0r_kid | A 90s IRC gamer kid with leet speak and old-school internet vibes |
-| `uncensored` | 🔓 Uncensored | Enhanced personality that uses local LLM for less restricted responses |
-
-### Uncensored Mode
-
-When available, you can get less restricted responses by either:
-- Using `/chat message:<text> uncensored:true` with any personality
-- Choosing the `uncensored` personality directly
-
-Uncensored responses are marked with a 🔓 emoji. This requires the bot admin to have a local LLM (Ollama) configured.
 
 ---
 
@@ -195,11 +163,10 @@ React to a bot's summary message with the 📚 (books) emoji to mark that articl
 ## Tips
 
 - Type `/` in Discord to see all available bot commands with autocomplete
-- **Reply to bot messages** to continue personality chats or ask follow-up questions about summaries
+- **Reply to bot messages** to ask follow-up questions about summaries or regenerate images
 - If the bot detects a questionable source, it will add a ⚠️ warning
-- Personalities maintain their character throughout conversations
-- Multiple users can participate in the same personality conversation - it's like a group chat with a character
-- Mention the bot (`@BotName`) to start a conversation with the default personality
+- Multiple users can participate in the same conversation - the bot knows who said what
+- Mention the bot (`@BotName`) to start a conversation
 
 ---
 
@@ -210,13 +177,11 @@ React to a bot's summary message with the 📚 (books) emoji to mark that articl
 | `/help` | Show all commands |
 | `/summarize url:<url>` | Summarize an article |
 | `/resummarize url:<url>` | Re-summarize (bypass cache) |
-| `/personalities` | List chat personalities |
-| `/chat message:<msg>` | Chat with default personality |
-| `/chat message:<msg> personality:<id>` | Chat with a specific personality |
+| `/chat message:<msg>` | Chat with the bot |
 | `/chatthread message:<msg>` | Start a chat thread |
 | `/chatlist` | List resumable conversations |
-| `/chatresume personality:<id> message:<msg>` | Resume expired conversation |
-| `/chatreset personality:<id>` | Reset conversation (admin) |
+| `/chatresume message:<msg>` | Resume expired conversation |
+| `/chatreset` | Reset conversation (admin) |
 | `/imagine prompt:<text>` | Generate an image |
 | `/videogen prompt:<text>` | Generate a video |
 | `/memories` | View your memories |


### PR DESCRIPTION
## Summary
- Remove personality picker and uncensored option from `/chat`, `/chatthread`, `/chatresume`, `/chatreset`, `/chatlist`
- All chat commands now use channel-voice personality exclusively
- Simplified response format: `**Prompt:** <message>\n\n<response>` (no emoji/name header)
- Thread names now use the opening message instead of personality name
- Updated user docs and features docs to reflect the simpler interface
- Net -170 lines of code removed

## Test plan
- [x] 10 tests in ChatCommand.test.js covering new behavior
- [x] Full suite passes (663 tests, 21 suites)
- [x] Deployed to k8s as v2.8.0
- [ ] Verify `/chat` works without personality option in Discord
- [ ] Verify `/chatthread` creates thread without personality picker
- [ ] Note: slash command option changes take up to 1 hour to propagate globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)