### PR TITLE
chore: remove dead personality detection and routing code

### DIFF
--- a/__tests__/handlers/ReplyHandler.test.js
+++ b/__tests__/handlers/ReplyHandler.test.js
@@ -9,48 +9,7 @@ jest.mock('../../logger', () => ({
   warn: jest.fn()
 }));
 
-// Mock the personality manager
-jest.mock('../../personalities', () => ({
-  get: jest.fn((id) => {
-    const personalities = {
-      'noir-detective': {
-        id: 'noir-detective',
-        name: 'Jack Shadows',
-        emoji: '🕵️',
-        description: 'A hardboiled 1940s detective',
-        systemPrompt: 'You are Jack Shadows, a noir detective.'
-      },
-      'grumpy-historian': {
-        id: 'grumpy-historian',
-        name: 'Professor Grimsworth',
-        emoji: '📚',
-        description: 'A grumpy historian',
-        systemPrompt: 'You are Professor Grimsworth.'
-      }
-    };
-    return personalities[id] || null;
-  }),
-  getAll: jest.fn(() => [
-    {
-      id: 'noir-detective',
-      name: 'Jack Shadows',
-      emoji: '🕵️',
-      description: 'A hardboiled 1940s detective',
-      systemPrompt: 'You are Jack Shadows, a noir detective.'
-    },
-    {
-      id: 'grumpy-historian',
-      name: 'Professor Grimsworth',
-      emoji: '📚',
-      description: 'A grumpy historian',
-      systemPrompt: 'You are Professor Grimsworth.'
-    }
-  ]),
-  list: jest.fn(() => [
-    { id: 'noir-detective', name: 'Jack Shadows', emoji: '🕵️', description: 'A hardboiled 1940s detective' },
-    { id: 'grumpy-historian', name: 'Professor Grimsworth', emoji: '📚', description: 'A grumpy historian' }
-  ])
-}));
+// Personality manager no longer used by ReplyHandler (personality detection removed)
 
 describe('ReplyHandler', () => {
   let replyHandler;
@@ -65,19 +24,14 @@ describe('ReplyHandler', () => {
     mockChatService = {
       chat: jest.fn().mockResolvedValue({
         success: true,
-        message: 'Test response from personality',
+        message: 'Test response',
         personality: {
-          id: 'noir-detective',
-          name: 'Jack Shadows',
-          emoji: '🕵️'
+          id: 'channel-voice',
+          name: 'Channel Voice',
+          emoji: '🗣️'
         },
         tokens: { input: 100, output: 50, total: 150 }
-      }),
-      mongoService: {
-        getConversationStatus: jest.fn().mockResolvedValue({ exists: false }),
-        isConversationIdle: jest.fn().mockResolvedValue(false),
-        recordTokenUsage: jest.fn().mockResolvedValue(true)
-      }
+      })
     };
 
     mockSummarizationService = {
@@ -107,41 +61,6 @@ describe('ReplyHandler', () => {
       mockOpenAIClient,
       mockConfig
     );
-  });
-
-  describe('detectPersonalityFromMessage', () => {
-    it('should detect noir-detective from message format', () => {
-      const content = '🕵️ **Jack Shadows**\n\nThe question came at me like a blonde in a red dress.';
-      const result = replyHandler.detectPersonalityFromMessage(content);
-
-      expect(result).not.toBeNull();
-      expect(result.id).toBe('noir-detective');
-      expect(result.name).toBe('Jack Shadows');
-      expect(result.emoji).toBe('🕵️');
-    });
-
-    it('should detect grumpy-historian from message format', () => {
-      const content = '📚 **Professor Grimsworth**\n\nAh yes, this reminds me of ancient Rome.';
-      const result = replyHandler.detectPersonalityFromMessage(content);
-
-      expect(result).not.toBeNull();
-      expect(result.id).toBe('grumpy-historian');
-      expect(result.name).toBe('Professor Grimsworth');
-    });
-
-    it('should return null for non-personality messages', () => {
-      const content = 'This is just a regular message without personality formatting.';
-      const result = replyHandler.detectPersonalityFromMessage(content);
-
-      expect(result).toBeNull();
-    });
-
-    it('should return null for summarization messages', () => {
-      const content = '**Article Title**\n\nSummary text here.\n\n**Reading Time:** 5 min';
-      const result = replyHandler.detectPersonalityFromMessage(content);
-
-      expect(result).toBeNull();
-    });
   });
 
   describe('isSummarizationMessage', () => {
@@ -236,7 +155,7 @@ describe('ReplyHandler', () => {
 
       mockReferencedMessage = {
         author: { bot: true },
-        content: '🕵️ **Jack Shadows**\n\nThe rain fell like memories of a case gone cold.'
+        content: 'Just a regular bot message.'
       };
     });
 
@@ -244,20 +163,6 @@ describe('ReplyHandler', () => {
       mockReferencedMessage.author.bot = false;
       const result = await replyHandler.handleReply(mockMessage, mockReferencedMessage);
       expect(result).toBe(false);
-    });
-
-    it('should handle personality chat reply', async () => {
-      const result = await replyHandler.handleReply(mockMessage, mockReferencedMessage);
-
-      expect(result).toBe(true);
-      expect(mockChatService.chat).toHaveBeenCalledWith(
-        'noir-detective',
-        'Continue the story!',
-        mockMessage.author,
-        'channel123',
-        'guild456'
-      );
-      expect(mockMessage.reply).toHaveBeenCalled();
     });
 
     it('should handle summarization follow-up reply', async () => {
@@ -276,90 +181,6 @@ describe('ReplyHandler', () => {
       const result = await replyHandler.handleReply(mockMessage, mockReferencedMessage);
 
       expect(result).toBe(false);
-    });
-  });
-
-  describe('handlePersonalityChatReply', () => {
-    let mockMessage;
-    const personalityInfo = {
-      id: 'noir-detective',
-      name: 'Jack Shadows',
-      emoji: '🕵️'
-    };
-
-    beforeEach(() => {
-      mockMessage = {
-        content: 'Tell me more about the case.',
-        author: {
-          id: 'user123',
-          username: 'TestUser',
-          tag: 'TestUser#1234'
-        },
-        channel: {
-          id: 'channel123',
-          send: jest.fn().mockResolvedValue({}),
-          sendTyping: jest.fn().mockResolvedValue({})
-        },
-        guild: { id: 'guild456' },
-        reply: jest.fn().mockResolvedValue({})
-      };
-    });
-
-    it('should continue active conversation', async () => {
-      mockChatService.mongoService.getConversationStatus.mockResolvedValue({
-        exists: true,
-        status: 'active'
-      });
-
-      await replyHandler.handlePersonalityChatReply(mockMessage, personalityInfo);
-
-      expect(mockChatService.chat).toHaveBeenCalledWith(
-        'noir-detective',
-        'Tell me more about the case.',
-        mockMessage.author,
-        'channel123',
-        'guild456'
-      );
-    });
-
-    it('should handle expired conversation with in-character response', async () => {
-      mockChatService.mongoService.getConversationStatus.mockResolvedValue({
-        exists: true,
-        status: 'expired'
-      });
-
-      await replyHandler.handlePersonalityChatReply(mockMessage, personalityInfo);
-
-      // Should call OpenAI for in-character "forgotten" response
-      expect(mockOpenAIClient.responses.create).toHaveBeenCalled();
-      expect(mockMessage.reply).toHaveBeenCalled();
-
-      // Should NOT continue the conversation
-      expect(mockChatService.chat).not.toHaveBeenCalled();
-    });
-
-    it('should let chatService handle idle conversations (start fresh)', async () => {
-      mockChatService.mongoService.getConversationStatus.mockResolvedValue({
-        exists: true,
-        status: 'active'
-      });
-      // Note: isConversationIdle is no longer checked in ReplyHandler
-      // chatService.chat() handles idle detection and starts fresh if needed
-
-      await replyHandler.handlePersonalityChatReply(mockMessage, personalityInfo);
-
-      // Should continue to chatService (which will handle idle internally)
-      expect(mockChatService.chat).toHaveBeenCalled();
-    });
-
-    it('should format response with personality header', async () => {
-      await replyHandler.handlePersonalityChatReply(mockMessage, personalityInfo);
-
-      expect(mockMessage.reply).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: expect.stringContaining('🕵️ **Jack Shadows**')
-        })
-      );
     });
   });
 
@@ -426,60 +247,6 @@ describe('ReplyHandler', () => {
     });
   });
 
-  describe('handleExpiredConversationReply', () => {
-    let mockMessage;
-    const personalityInfo = {
-      id: 'noir-detective',
-      name: 'Jack Shadows',
-      emoji: '🕵️'
-    };
-
-    beforeEach(() => {
-      mockMessage = {
-        content: 'Remember what we talked about?',
-        author: { id: 'user123', username: 'TestUser' },
-        channel: {
-          send: jest.fn().mockResolvedValue({}),
-          sendTyping: jest.fn().mockResolvedValue({})
-        },
-        reply: jest.fn().mockResolvedValue({})
-      };
-    });
-
-    it('should generate in-character forgotten response', async () => {
-      await replyHandler.handleExpiredConversationReply(mockMessage, personalityInfo);
-
-      expect(mockOpenAIClient.responses.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          instructions: expect.stringContaining('forgotten what you were talking about')
-        })
-      );
-    });
-
-    it('should include command hint in response', async () => {
-      await replyHandler.handleExpiredConversationReply(mockMessage, personalityInfo);
-
-      expect(mockMessage.reply).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: expect.stringContaining('!chat noir-detective')
-        })
-      );
-    });
-
-    it('should handle OpenAI errors gracefully', async () => {
-      mockOpenAIClient.responses.create.mockRejectedValue(new Error('API Error'));
-
-      await replyHandler.handleExpiredConversationReply(mockMessage, personalityInfo);
-
-      // Should still reply with a fallback message
-      expect(mockMessage.reply).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: expect.stringContaining('expired')
-        })
-      );
-    });
-  });
-
   describe('splitMessage', () => {
     it('should not split short messages', () => {
       const text = 'Short message';
@@ -499,20 +266,6 @@ describe('ReplyHandler', () => {
       const text = 'word '.repeat(500); // 2500 chars
       const chunks = replyHandler.splitMessage(text, 2000);
       expect(chunks.length).toBeGreaterThan(1);
-    });
-  });
-
-  describe('escapeRegex', () => {
-    it('should escape special regex characters', () => {
-      expect(replyHandler.escapeRegex('test.string')).toBe('test\\.string');
-      expect(replyHandler.escapeRegex('test*string')).toBe('test\\*string');
-      expect(replyHandler.escapeRegex('test?string')).toBe('test\\?string');
-      expect(replyHandler.escapeRegex('test[string]')).toBe('test\\[string\\]');
-    });
-
-    it('should handle emojis correctly', () => {
-      // Emojis don't need escaping but shouldn't break
-      expect(replyHandler.escapeRegex('🕵️')).toBe('🕵️');
     });
   });
 
@@ -838,21 +591,5 @@ describe('ReplyHandler', () => {
       expect(mockImagenService.generateImage).toHaveBeenCalled();
     });
 
-    it('should prioritize personality detection over image detection', async () => {
-      // Message that looks like both personality and image
-      mockReferencedMessage.content = '🕵️ **Jack Shadows**\n\nHere is the image.';
-      mockReferencedMessage.attachments = {
-        size: 1,
-        first: () => ({ contentType: 'image/png' }),
-        map: (fn) => [fn({ contentType: 'image/png' })]
-      };
-
-      const result = await replyHandler.handleReply(mockMessage, mockReferencedMessage);
-
-      expect(result).toBe(true);
-      // Should use personality chat, not image reply
-      expect(mockChatService.chat).toHaveBeenCalled();
-      expect(mockImagenService.generateImage).not.toHaveBeenCalled();
-    });
   });
 });

--- a/__tests__/services/ChatService.test.js
+++ b/__tests__/services/ChatService.test.js
@@ -155,7 +155,6 @@ describe('ChatService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Unknown personality');
-      expect(result.availablePersonalities).toBeDefined();
     });
   });
 

--- a/handlers/ReplyHandler.js
+++ b/handlers/ReplyHandler.js
@@ -1,12 +1,11 @@
 // handlers/ReplyHandler.js
-// Handles replies to bot messages for personality chats, summarization follow-ups, and image regeneration
+// Handles replies to bot messages for summarization follow-ups and image regeneration
 
 const { AttachmentBuilder } = require('discord.js');
 const logger = require('../logger');
-const personalityManager = require('../personalities');
 const TextUtils = require('../utils/textUtils');
 const { withRootSpan, withSpan, setSpanAttributes } = require('../tracing');
-const { DISCORD, REPLY, ERROR, CHAT, SUMMARIZATION } = require('../tracing-attributes');
+const { DISCORD, REPLY, ERROR, SUMMARIZATION } = require('../tracing-attributes');
 
 class ReplyHandler {
   constructor(chatService, summarizationService, openaiClient, config, imagenService = null) {
@@ -40,20 +39,6 @@ class ReplyHandler {
       [DISCORD.MESSAGE_ID]: message.id,
       [REPLY.OPERATION]: 'handle_reply',
     }, async (span) => {
-      // Try to detect if this is a personality chat message
-      const personalityInfo = this.detectPersonalityFromMessage(botContent);
-      if (personalityInfo) {
-        logger.info(`Detected reply to personality chat: ${personalityInfo.id}`);
-        span.setAttributes({
-          [REPLY.TYPE]: 'personality_chat',
-          [REPLY.PERSONALITY_DETECTED]: true,
-          [CHAT.PERSONALITY_ID]: personalityInfo.id,
-          [CHAT.PERSONALITY_NAME]: personalityInfo.name,
-        });
-        await this.handlePersonalityChatReply(message, personalityInfo);
-        return true;
-      }
-
       // Try to detect if this is a summarization message
       if (this.isSummarizationMessage(botContent)) {
         logger.info('Detected reply to summarization message');
@@ -85,41 +70,6 @@ class ReplyHandler {
       span.setAttribute(REPLY.TYPE, 'unhandled');
       return false;
     });
-  }
-
-  /**
-   * Detect personality from a bot message by looking for emoji + name pattern
-   * Bot messages are formatted as: "🕵️ **Jack Shadows**\n\n<message>"
-   * @param {string} content - The bot message content
-   * @returns {Object|null} Personality info {id, name, emoji} or null if not detected
-   */
-  detectPersonalityFromMessage(content) {
-    // Get all personalities and try to match
-    const personalities = personalityManager.getAll();
-
-    for (const personality of personalities) {
-      // Check for the format: "emoji **Name**" at the start of the message
-      const pattern = new RegExp(`^${this.escapeRegex(personality.emoji)}\\s*\\*\\*${this.escapeRegex(personality.name)}\\*\\*`, 'i');
-
-      if (pattern.test(content)) {
-        return {
-          id: personality.id,
-          name: personality.name,
-          emoji: personality.emoji
-        };
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * Escape special regex characters in a string
-   * @param {string} str - String to escape
-   * @returns {string} Escaped string
-   */
-  escapeRegex(str) {
-    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 
   /**
@@ -374,179 +324,6 @@ Create an enhanced prompt that incorporates this feedback:`;
       'image/webp': 'webp'
     };
     return extensions[mimeType] || 'png';
-  }
-
-  /**
-   * Handle a reply to a personality chat message
-   * @param {Message} message - The user's reply message
-   * @param {Object} personalityInfo - The detected personality info
-   */
-  async handlePersonalityChatReply(message, personalityInfo) {
-    return withSpan('discord.reply.personality_chat', {
-      [CHAT.PERSONALITY_ID]: personalityInfo.id,
-      [CHAT.PERSONALITY_NAME]: personalityInfo.name,
-      [DISCORD.CHANNEL_ID]: message.channel.id,
-    }, async (span) => {
-      const channelId = message.channel.id;
-      const guildId = message.guild?.id || null;
-      const userMessage = message.content;
-
-      // Show typing indicator
-      await message.channel.sendTyping();
-
-      // For replies, we let chatService.chat() handle the conversation logic
-      // It will check for idle timeout and either continue or start fresh
-      // We only show the "forgotten" message if the conversation was explicitly
-      // expired or reset (not just idle - idle conversations get auto-renewed by !chat)
-      const status = await this.chatService.mongoService.getConversationStatus(channelId, personalityInfo.id);
-
-      logger.debug(`Reply handler - conversation status for ${personalityInfo.id} in ${channelId}: ${JSON.stringify(status)}`);
-      span.setAttribute(REPLY.CONVERSATION_STATUS, status.status || 'new');
-
-      // Only show forgotten message for explicitly expired/reset conversations
-      // For idle conversations, chatService.chat() will handle them (start fresh)
-      if (status.exists && (status.status === 'expired' || status.status === 'reset')) {
-        logger.info(`Conversation ${personalityInfo.id} is ${status.status}, showing expired message`);
-        // Conversation was explicitly expired or reset - respond in character about forgetting
-        await this.handleExpiredConversationReply(message, personalityInfo);
-        return;
-      }
-
-      // Continue the conversation (or start fresh if idle - chatService handles this)
-      const result = await this.chatService.chat(
-        personalityInfo.id,
-        userMessage,
-        message.author,
-        channelId,
-        guildId
-      );
-
-      if (!result.success) {
-        span.setAttributes({
-          [ERROR.TYPE]: 'chat_error',
-          [ERROR.MESSAGE]: result.error || 'Unknown error',
-        });
-        if (result.availablePersonalities) {
-          return message.reply({
-            content: `I couldn't find that personality. Something went wrong.`,
-            allowedMentions: { repliedUser: false }
-          });
-        }
-        return message.reply({
-          content: result.error,
-          allowedMentions: { repliedUser: false }
-        });
-      }
-
-      span.setAttribute(CHAT.HAS_IMAGE, result.images?.length > 0);
-
-      // Format response with personality header and wrap URLs
-      const response = TextUtils.wrapUrls(
-        `${result.personality.emoji} **${result.personality.name}**\n\n${result.message}`
-      );
-
-      // Convert any generated images to Discord attachments
-      const imageAttachments = this._createImageAttachments(result.images);
-
-      // Split if too long for Discord
-      if (response.length > 2000) {
-        const chunks = this.splitMessage(response, 2000);
-        for (const chunk of chunks) {
-          await message.channel.send(chunk);
-        }
-        // Send images after text chunks
-        if (imageAttachments.length > 0) {
-          await message.channel.send({ files: imageAttachments });
-        }
-      } else {
-        await message.reply({
-          content: response,
-          allowedMentions: { repliedUser: false }
-        });
-        // Send images as follow-up
-        if (imageAttachments.length > 0) {
-          await message.channel.send({ files: imageAttachments });
-        }
-      }
-    });
-  }
-
-  /**
-   * Create Discord attachments from base64 images
-   * @param {Array<{id: string, base64: string}>} images - Generated images
-   * @returns {Array<AttachmentBuilder>} Discord attachment builders
-   * @private
-   */
-  _createImageAttachments(images) {
-    const attachments = [];
-    if (!images || images.length === 0) {
-      return attachments;
-    }
-
-    for (let i = 0; i < images.length; i++) {
-      const img = images[i];
-      try {
-        const buffer = Buffer.from(img.base64, 'base64');
-        const attachment = new AttachmentBuilder(buffer, {
-          name: `generated_image_${i + 1}.png`
-        });
-        attachments.push(attachment);
-        logger.info(`Prepared image attachment: generated_image_${i + 1}.png`);
-      } catch (error) {
-        logger.error(`Failed to create image attachment: ${error.message}`);
-      }
-    }
-
-    return attachments;
-  }
-
-  /**
-   * Handle reply to an expired personality conversation
-   * Responds in character about having forgotten the conversation
-   * @param {Message} message - The user's reply message
-   * @param {Object} personalityInfo - The detected personality info
-   */
-  async handleExpiredConversationReply(message, personalityInfo) {
-    const personality = personalityManager.get(personalityInfo.id);
-
-    if (!personality) {
-      return message.reply({
-        content: `I couldn't find that personality.`,
-        allowedMentions: { repliedUser: false }
-      });
-    }
-
-    // Generate an in-character "I've forgotten" response
-    const forgetPrompt = `${personality.systemPrompt}
-
-The user is trying to continue a conversation with you, but too much time has passed (30+ minutes of inactivity) and you've completely forgotten what you were talking about.
-
-Respond IN CHARACTER explaining that you don't remember what you were discussing. Stay true to your personality while letting them know they need to start a new conversation. Be brief (1-2 sentences max). Do NOT use phrases like "start a new conversation" or mention commands - just express confusion about what they were talking about in your character's unique voice.`;
-
-    try {
-      const response = await this.openaiClient.responses.create({
-        model: this.config.openai.model || 'gpt-5.1',
-        instructions: forgetPrompt,
-        input: message.content,
-      });
-
-      const characterResponse = response.output_text;
-
-      // Add the command hint after the in-character response
-      const fullResponse = `${personalityInfo.emoji} **${personalityInfo.name}**\n\n${characterResponse}\n\n*This conversation has expired. Start a new one with \`!chat ${personalityInfo.id} <message>\`*`;
-
-      await message.reply({
-        content: fullResponse,
-        allowedMentions: { repliedUser: false }
-      });
-
-    } catch (error) {
-      logger.error(`Error generating expired conversation response: ${error.message}`);
-      await message.reply({
-        content: `${personalityInfo.emoji} **${personalityInfo.name}**\n\n*This conversation has expired after 30 minutes of inactivity. Start a new one with \`!chat ${personalityInfo.id} <message>\`*`,
-        allowedMentions: { repliedUser: false }
-      });
-    }
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-article-archiver-bot",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "license": "MIT",
   "description": "A Discord bot that integrates with Linkwarden for self-hosted article archiving and uses OpenAI-compatible APIs to automatically generate summaries of archived articles with support for authenticated/paywalled content.",
   "main": "bot.js",

--- a/services/ChatService.js
+++ b/services/ChatService.js
@@ -395,12 +395,9 @@ ${context}`;
    * @param {string} channelId - Discord channel ID
    * @param {string} guildId - Discord guild ID
    * @param {string|null} imageUrl - Optional image URL for vision
-   * @param {Object} options - Additional options
-   * @param {boolean} options.useUncensored - Use local LLM for uncensored response
    * @returns {Object} Response with message and token usage
    */
-  async chat(personalityId, userMessage, user, channelId = null, guildId = null, imageUrl = null, options = {}) {
-    const { useUncensored = false } = options;
+  async chat(personalityId, userMessage, user, channelId = null, guildId = null, imageUrl = null) {
     const personality = personalityManager.get(personalityId);
 
     if (!personality) {
@@ -414,7 +411,7 @@ ${context}`;
           const fallbackPersonality = personalityManager.get(fallbackId);
           if (fallbackPersonality) {
             logger.warn(`Personality ${personalityId} unavailable (circuit open), falling back to ${fallbackId}`);
-            const result = await this.chat(fallbackId, userMessage, user, channelId, guildId, imageUrl, options);
+            const result = await this.chat(fallbackId, userMessage, user, channelId, guildId, imageUrl);
             if (result.success) {
               result.fallback = {
                 occurred: true,
@@ -432,13 +429,12 @@ ${context}`;
       }
       return {
         success: false,
-        error: `Unknown personality: ${personalityId}`,
-        availablePersonalities: personalityManager.list()
+        error: `Unknown personality: ${personalityId}`
       };
     }
 
-    // Check if personality requires local LLM (or user explicitly requested uncensored)
-    const shouldUseLocalLlm = useUncensored || personality.useLocalLlm;
+    // Check if personality requires local LLM
+    const shouldUseLocalLlm = personality.useLocalLlm;
 
     // If no channelId provided, fall back to stateless mode (backwards compatibility)
     if (!channelId || !this.mongoService) {
@@ -853,8 +849,7 @@ ${context}`;
     if (!personality) {
       return {
         success: false,
-        error: `Unknown personality: ${personalityId}`,
-        availablePersonalities: personalityManager.list()
+        error: `Unknown personality: ${personalityId}`
       };
     }
 


### PR DESCRIPTION
## Summary
- Remove personality detection from ReplyHandler (detectPersonalityFromMessage, escapeRegex, handlePersonalityChatReply, handleExpiredConversationReply)
- Remove personality detection path from handleReply() — only summarization and image generation replies remain
- Remove `useUncensored` parameter from ChatService.chat()
- Remove `availablePersonalities` from ChatService error responses
- Clean up related tests (~200 lines of dead test code removed)
- Net -507 lines removed

Stacked on #60 (chore/cleanup-unused-personalities).

## Test plan
- [x] Full suite passes (644 tests, 21 suites)
- [x] Deployed to k8s as v2.8.2
- [x] Bot replies to summarization and image generation messages still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)