### PR TITLE
feat: auto-retry image generation with simplified prompt

### DIFF
--- a/__tests__/handlers/ImageRetryHandler.test.js
+++ b/__tests__/handlers/ImageRetryHandler.test.js
@@ -364,6 +364,182 @@ describe('ImageRetryHandler', () => {
     });
   });
 
+  describe('auto-retry on failure', () => {
+    const failureContext = {
+      type: 'no_image',
+      originalPrompt: 'A complex prompt that failed',
+      details: { finishReason: 'NO_IMAGE' }
+    };
+
+    it('should auto-retry with highest-confidence suggestion when enabled', async () => {
+      mockImagePromptAnalyzerService.analyzeFailedPrompt.mockResolvedValue({
+        failureType: 'no_image',
+        analysis: 'Prompt too complex.',
+        suggestedPrompts: ['Simpler prompt A', 'Simpler prompt B'],
+        confidence: 0.85
+      });
+
+      mockImagenService.generateImage.mockResolvedValue({
+        success: true,
+        buffer: Buffer.from('auto-retry-image'),
+        mimeType: 'image/png',
+        prompt: 'Simpler prompt A'
+      });
+
+      await handler.handleFailedGeneration(
+        mockMessage,
+        'A complex prompt that failed',
+        failureContext,
+        mockUser
+      );
+
+      // Should have attempted auto-retry with first suggestion
+      expect(mockImagenService.generateImage).toHaveBeenCalledWith(
+        'Simpler prompt A',
+        expect.objectContaining({ isAdmin: false }),
+        mockUser
+      );
+
+      // Should send the image to the channel
+      expect(mockMessage.channel.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          files: expect.any(Array)
+        })
+      );
+    });
+
+    it('should fall back to interactive embed when auto-retry fails', async () => {
+      mockImagePromptAnalyzerService.analyzeFailedPrompt.mockResolvedValue({
+        failureType: 'no_image',
+        analysis: 'Prompt too complex.',
+        suggestedPrompts: ['Simpler prompt A', 'Simpler prompt B'],
+        confidence: 0.85
+      });
+
+      mockImagenService.generateImage.mockResolvedValue({
+        success: false,
+        error: 'Still failed'
+      });
+
+      await handler.handleFailedGeneration(
+        mockMessage,
+        'A complex prompt that failed',
+        failureContext,
+        mockUser
+      );
+
+      // Should have attempted auto-retry
+      expect(mockImagenService.generateImage).toHaveBeenCalled();
+
+      // Should fall back to sending interactive embed with reactions
+      const sendCalls = mockMessage.channel.send.mock.calls;
+      const embedCall = sendCalls.find(call => call[0]?.embeds);
+      expect(embedCall).toBeDefined();
+    });
+
+    it('should skip auto-retry for safety blocks', async () => {
+      const safetyContext = {
+        type: 'safety',
+        originalPrompt: 'Something blocked',
+        details: { finishReason: 'SAFETY' }
+      };
+
+      mockImagePromptAnalyzerService.analyzeFailedPrompt.mockResolvedValue({
+        failureType: 'safety',
+        analysis: 'Blocked by safety filters.',
+        suggestedPrompts: ['Alternative prompt'],
+        confidence: 0.9
+      });
+
+      await handler.handleFailedGeneration(
+        mockMessage,
+        'Something blocked',
+        safetyContext,
+        mockUser
+      );
+
+      // Should NOT auto-retry for safety blocks
+      expect(mockImagenService.generateImage).not.toHaveBeenCalled();
+
+      // Should go straight to interactive embed
+      const sendCalls = mockMessage.channel.send.mock.calls;
+      const embedCall = sendCalls.find(call => call[0]?.embeds);
+      expect(embedCall).toBeDefined();
+    });
+
+    it('should skip auto-retry when no suggestions available', async () => {
+      mockImagePromptAnalyzerService.analyzeFailedPrompt.mockResolvedValue({
+        failureType: 'no_image',
+        analysis: 'Unable to analyze.',
+        suggestedPrompts: [],
+        confidence: 0
+      });
+
+      await handler.handleFailedGeneration(
+        mockMessage,
+        'Some prompt',
+        failureContext,
+        mockUser
+      );
+
+      expect(mockImagenService.generateImage).not.toHaveBeenCalled();
+    });
+
+    it('should skip auto-retry when config disables it', async () => {
+      const handlerNoAutoRetry = new ImageRetryHandler(
+        mockImagenService,
+        mockImagePromptAnalyzerService,
+        { discord: { adminUserIds: [] }, imagen: { autoRetry: false } }
+      );
+
+      mockImagePromptAnalyzerService.analyzeFailedPrompt.mockResolvedValue({
+        failureType: 'no_image',
+        analysis: 'Prompt too complex.',
+        suggestedPrompts: ['Simpler prompt'],
+        confidence: 0.85
+      });
+
+      await handlerNoAutoRetry.handleFailedGeneration(
+        mockMessage,
+        'A complex prompt',
+        failureContext,
+        mockUser
+      );
+
+      expect(mockImagenService.generateImage).not.toHaveBeenCalled();
+    });
+
+    it('should notify user that auto-retry is in progress', async () => {
+      mockImagePromptAnalyzerService.analyzeFailedPrompt.mockResolvedValue({
+        failureType: 'no_image',
+        analysis: 'Prompt too complex.',
+        suggestedPrompts: ['Simpler prompt'],
+        confidence: 0.85
+      });
+
+      mockImagenService.generateImage.mockResolvedValue({
+        success: true,
+        buffer: Buffer.from('image-data'),
+        mimeType: 'image/png'
+      });
+
+      await handler.handleFailedGeneration(
+        mockMessage,
+        'Complex prompt',
+        failureContext,
+        mockUser
+      );
+
+      // Should have sent a "retrying" message
+      const sendCalls = mockMessage.channel.send.mock.calls;
+      const retryingCall = sendCalls.find(call =>
+        typeof call[0] === 'string' ? call[0].includes('etry') :
+        call[0]?.content?.includes('etry')
+      );
+      expect(retryingCall).toBeDefined();
+    });
+  });
+
   describe('cleanupExpiredRetries', () => {
     it('should remove retries older than timeout', () => {
       const oldTime = Date.now() - 120000; // 2 minutes ago

--- a/config/config.js
+++ b/config/config.js
@@ -182,7 +182,9 @@ module.exports = {
     // Maximum prompt length in characters
     maxPromptLength: parseInt(process.env.IMAGEGEN_MAX_PROMPT_LENGTH || '1000', 10),
     // Cooldown between image generations per user (in seconds)
-    cooldownSeconds: parseInt(process.env.IMAGEGEN_COOLDOWN_SECONDS || '30', 10)
+    cooldownSeconds: parseInt(process.env.IMAGEGEN_COOLDOWN_SECONDS || '30', 10),
+    // Auto-retry with simplified prompt on failure (skips safety blocks)
+    autoRetry: process.env.IMAGEGEN_AUTO_RETRY !== 'false' // default true
   },
   // Veo - Google Vertex AI video generation (first & last frame)
   veo: {

--- a/features.md
+++ b/features.md
@@ -65,8 +65,8 @@
 - **Per-User Cooldowns**: Configurable cooldown to prevent abuse
 - **Usage Tracking**: All generations tracked in MongoDB (including which model was used)
 - **Safety Filters**: Relies on Gemini's built-in content safety with detailed logging of FinishReason (SAFETY, IMAGE_SAFETY, IMAGE_PROHIBITED_CONTENT), BlockedReason, blockReasonMessage, and safety ratings
-- **Intelligent Retry**: When generation fails, AI analyzes the prompt and suggests alternatives
-- **Interactive Approval**: React with 1️⃣ 2️⃣ 3️⃣ to retry with suggested prompts, ❌ to dismiss
+- **Auto-Retry**: When generation fails (non-safety), AI automatically retries with a simplified prompt before falling back to interactive suggestions
+- **Interactive Fallback**: If auto-retry also fails, react with 1️⃣ 2️⃣ 3️⃣ to retry with suggested prompts, ❌ to dismiss
 - **Failure Analysis**: Detailed analysis of why prompts fail (safety, rate limits, etc.)
 - **Learning Loop**: Retry attempts tracked in MongoDB to improve future suggestions
 - **Reply to Regenerate**: Reply to a generated image with feedback to create an enhanced version (aspect ratio directives are stripped to prevent conflicts with the image generation API)

--- a/handlers/ImageRetryHandler.js
+++ b/handlers/ImageRetryHandler.js
@@ -63,70 +63,51 @@ class ImageRetryHandler {
         };
       });
 
-      // Format the analysis as an embed
-      const embedData = this.analyzerService.formatAnalysisForEmbed(analysis);
-      const embed = new EmbedBuilder()
-        .setTitle(embedData.title)
-        .setDescription(embedData.description)
-        .setColor(embedData.color)
-        .setFooter(embedData.footer);
+      // Auto-retry: if enabled, not a safety block, and we have suggestions, try once automatically
+      const autoRetryEnabled = this.config.imagen?.autoRetry !== false; // default true
+      const isSafetyBlock = failureContext.type === 'safety';
+      const hasSuggestions = analysis.suggestedPrompts?.length > 0;
 
-      for (const field of embedData.fields || []) {
-        embed.addFields(field);
-      }
+      if (autoRetryEnabled && !isSafetyBlock && hasSuggestions) {
+        const retryPrompt = analysis.suggestedPrompts[0];
+        logger.info(`Auto-retrying image generation with simplified prompt: "${retryPrompt}"`);
 
-      // Send the embed
-      const embedMessage = await message.channel.send({
-        embeds: [embed]
-      });
+        await message.channel.send({
+          content: `Image generation failed — automatically retrying with a simplified prompt...`
+        });
 
-      // Add reaction buttons for each suggested prompt
-      const numSuggestions = Math.min(analysis.suggestedPrompts?.length || 0, 3);
-      for (let i = 0; i < numSuggestions; i++) {
-        await embedMessage.react(NUMBER_EMOJIS[i]);
-      }
-      await embedMessage.react(DISMISS_EMOJI);
+        const isAdmin = this.config.discord?.adminUserIds?.includes(user.id) || false;
+        const retryResult = await this.imagenService.generateImage(retryPrompt, { isAdmin }, user);
 
-      // Record the analysis in the database
-      const recordResult = await this.analyzerService.recordFailureAnalysis(
-        originalPrompt,
-        analysis,
-        user.id,
-        message.channel.id,
-        {
-          guildId: message.guild?.id,
-          username: user.username
+        if (retryResult.success) {
+          logger.info(`Auto-retry succeeded for user ${user.username}`);
+          const attachment = new AttachmentBuilder(retryResult.buffer, {
+            name: `generated_${Date.now()}.png`
+          });
+          await message.channel.send({
+            content: `**Prompt:** ${retryPrompt}`,
+            files: [attachment]
+          });
+
+          // Record the successful auto-retry
+          const recordResult = await this.analyzerService.recordFailureAnalysis(
+            originalPrompt, analysis, user.id, message.channel.id,
+            { guildId: message.guild?.id, username: user.username }
+          );
+          if (recordResult.id) {
+            await this.analyzerService.updateRetryAttempt(recordResult.id, retryPrompt, true);
+          }
+          return;
         }
-      );
 
-      // Store pending retry data
-      const pendingData = {
-        userId: user.id,
-        originalPrompt,
-        suggestedPrompts: analysis.suggestedPrompts || [],
-        channelId: message.channel.id,
-        messageId: embedMessage.id,
-        analysisId: recordResult.id || null,
-        createdAt: Date.now()
-      };
+        logger.info(`Auto-retry also failed for user ${user.username}, falling back to interactive suggestions`);
+      }
 
-      this.pendingRetries.set(embedMessage.id, pendingData);
-      logger.info(`Stored pending retry for embed message ${embedMessage.id}, total pending: ${this.pendingRetries.size}`);
-
-      // Set timeout to clean up
-      const timeout = setTimeout(() => {
-        this.pendingRetries.delete(embedMessage.id);
-        logger.debug(`Cleaned up expired pending retry: ${embedMessage.id}`);
-      }, RETRY_TIMEOUT_MS);
-
-      // Store timeout reference for cleanup
-      pendingData.timeout = timeout;
-
-      logger.info(`Handled failed generation for user ${user.username}, offered ${numSuggestions} alternatives, embedMessageId: ${embedMessage.id}`);
+      // Interactive fallback: send embed with suggestions and reaction buttons
+      await this._sendInteractiveEmbed(message, originalPrompt, failureContext, analysis, user);
 
     } catch (error) {
       logger.error(`Error handling failed generation: ${error.message}`);
-      // Try to send a simple error message as fallback
       try {
         await message.channel.send({
           content: `Image generation failed. Please try a different prompt.`
@@ -135,6 +116,74 @@ class ImageRetryHandler {
         logger.error(`Failed to send fallback error message: ${e.message}`);
       }
     }
+  }
+
+  /**
+   * Send interactive embed with suggestions and reaction buttons
+   * @param {Message} message - Discord message
+   * @param {string} originalPrompt - Original prompt that failed
+   * @param {Object} failureContext - Failure context
+   * @param {Object} analysis - Analysis result from analyzer service
+   * @param {Object} user - Discord user
+   * @private
+   */
+  async _sendInteractiveEmbed(message, originalPrompt, failureContext, analysis, user) {
+    const embedData = this.analyzerService.formatAnalysisForEmbed(analysis);
+    const embed = new EmbedBuilder()
+      .setTitle(embedData.title)
+      .setDescription(embedData.description)
+      .setColor(embedData.color)
+      .setFooter(embedData.footer);
+
+    for (const field of embedData.fields || []) {
+      embed.addFields(field);
+    }
+
+    const embedMessage = await message.channel.send({
+      embeds: [embed]
+    });
+
+    // Add reaction buttons for each suggested prompt
+    const numSuggestions = Math.min(analysis.suggestedPrompts?.length || 0, 3);
+    for (let i = 0; i < numSuggestions; i++) {
+      await embedMessage.react(NUMBER_EMOJIS[i]);
+    }
+    await embedMessage.react(DISMISS_EMOJI);
+
+    // Record the analysis in the database
+    const recordResult = await this.analyzerService.recordFailureAnalysis(
+      originalPrompt,
+      analysis,
+      user.id,
+      message.channel.id,
+      {
+        guildId: message.guild?.id,
+        username: user.username
+      }
+    );
+
+    // Store pending retry data
+    const pendingData = {
+      userId: user.id,
+      originalPrompt,
+      suggestedPrompts: analysis.suggestedPrompts || [],
+      channelId: message.channel.id,
+      messageId: embedMessage.id,
+      analysisId: recordResult.id || null,
+      createdAt: Date.now()
+    };
+
+    this.pendingRetries.set(embedMessage.id, pendingData);
+    logger.info(`Stored pending retry for embed message ${embedMessage.id}, total pending: ${this.pendingRetries.size}`);
+
+    // Set timeout to clean up
+    const timeout = setTimeout(() => {
+      this.pendingRetries.delete(embedMessage.id);
+      logger.debug(`Cleaned up expired pending retry: ${embedMessage.id}`);
+    }, RETRY_TIMEOUT_MS);
+
+    pendingData.timeout = timeout;
+    logger.info(`Handled failed generation for user ${user.username}, offered ${numSuggestions} alternatives, embedMessageId: ${embedMessage.id}`);
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-article-archiver-bot",
-      "version": "2.8.2",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "license": "MIT",
   "description": "A Discord bot that integrates with Linkwarden for self-hosted article archiving and uses OpenAI-compatible APIs to automatically generate summaries of archived articles with support for authenticated/paywalled content.",
   "main": "bot.js",


### PR DESCRIPTION
## Summary
- When image generation fails (non-safety), the bot now automatically retries once with a simplified prompt from the AI analyzer
- If auto-retry succeeds, the image is sent directly — no user interaction needed
- If auto-retry also fails, falls back to the existing interactive embed with reaction buttons
- Safety blocks skip auto-retry entirely (prompt rewording won't help)
- New config toggle: `IMAGEGEN_AUTO_RETRY` (default: true, set to `false` to disable)
- Extracted `_sendInteractiveEmbed()` to keep the code clean

## Flow
```
Generation fails → Analyze prompt → Auto-retry with best suggestion
                                     ├─ Success → Send image ✓
                                     └─ Failure → Interactive embed with 1️⃣2️⃣3️⃣ reactions
```

Stacked on #61 (chore/cleanup-personality-routing).

## Test plan
- [x] 6 new tests covering all auto-retry scenarios
- [x] Full suite passes (650 tests, 21 suites)
- [x] Deployed to k8s as v2.9.0
- [ ] Trigger a NO_IMAGE failure and verify auto-retry kicks in
- [ ] Trigger a SAFETY block and verify it goes straight to interactive embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)