### PR TITLE
feat: add /catchmeup command for DM-based activity summaries

### DIFF
--- a/__tests__/commands/slash/CatchMeUpCommand.test.js
+++ b/__tests__/commands/slash/CatchMeUpCommand.test.js
@@ -1,0 +1,115 @@
+// __tests__/commands/slash/CatchMeUpCommand.test.js
+
+jest.mock('../../../logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn()
+}));
+
+const CatchMeUpSlashCommand = require('../../../commands/slash/CatchMeUpCommand');
+
+describe('CatchMeUpSlashCommand', () => {
+  let command;
+  let mockCatchMeUpService;
+  let mockInteraction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockCatchMeUpService = {
+      generateCatchUp: jest.fn().mockResolvedValue({
+        success: true,
+        message: 'Here is what you missed: lots of AI papers and some k8s drama.'
+      })
+    };
+
+    mockInteraction = {
+      user: {
+        id: 'user123',
+        tag: 'TestUser#1234',
+        send: jest.fn().mockResolvedValue({})
+      },
+      guild: { id: 'guild456' },
+      editReply: jest.fn().mockResolvedValue({}),
+      deferReply: jest.fn().mockResolvedValue({}),
+      reply: jest.fn().mockResolvedValue({}),
+      followUp: jest.fn().mockResolvedValue({}),
+      deferred: true,
+      replied: false
+    };
+
+    command = new CatchMeUpSlashCommand(mockCatchMeUpService);
+  });
+
+  describe('execute', () => {
+    it('should call generateCatchUp with user and guild IDs', async () => {
+      await command.execute(mockInteraction, {});
+
+      expect(mockCatchMeUpService.generateCatchUp).toHaveBeenCalledWith('user123', 'guild456');
+    });
+
+    it('should send catch-up via DM', async () => {
+      await command.execute(mockInteraction, {});
+
+      expect(mockInteraction.user.send).toHaveBeenCalledWith(
+        expect.stringContaining('what you missed')
+      );
+    });
+
+    it('should confirm to user in channel that DM was sent', async () => {
+      await command.execute(mockInteraction, {});
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('DM')
+        })
+      );
+    });
+
+    it('should handle nothing-new gracefully', async () => {
+      mockCatchMeUpService.generateCatchUp.mockResolvedValue({
+        success: true,
+        nothingNew: true,
+        message: 'Nothing notable happened.'
+      });
+
+      await command.execute(mockInteraction, {});
+
+      // Should still reply in channel, not DM (nothing to report)
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('Nothing notable')
+        })
+      );
+      expect(mockInteraction.user.send).not.toHaveBeenCalled();
+    });
+
+    it('should handle DM failure gracefully', async () => {
+      mockInteraction.user.send.mockRejectedValue(new Error('Cannot send messages to this user'));
+
+      await command.execute(mockInteraction, {});
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('couldn\'t send')
+        })
+      );
+    });
+
+    it('should handle service errors gracefully', async () => {
+      mockCatchMeUpService.generateCatchUp.mockResolvedValue({
+        success: false,
+        error: 'Something broke'
+      });
+
+      await command.execute(mockInteraction, {});
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('Something broke')
+        })
+      );
+    });
+  });
+});

--- a/__tests__/services/CatchMeUpService.test.js
+++ b/__tests__/services/CatchMeUpService.test.js
@@ -1,0 +1,148 @@
+// __tests__/services/CatchMeUpService.test.js
+
+jest.mock('../../logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn()
+}));
+
+const CatchMeUpService = require('../../services/CatchMeUpService');
+
+describe('CatchMeUpService', () => {
+  let service;
+  let mockMongoService;
+  let mockChannelContextService;
+  let mockVoiceProfileService;
+  let mockOpenAIClient;
+  let mockConfig;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockMongoService = {
+      getUserLastSeen: jest.fn().mockResolvedValue({
+        userId: 'user123',
+        guildId: 'guild456',
+        lastSeenAt: new Date('2026-04-08T00:00:00Z'),
+        activeChannels: ['channel1', 'channel2']
+      }),
+      getRecentArticleSummaries: jest.fn().mockResolvedValue([
+        { title: 'New AI Paper', topic: 'AI', summary: 'A paper about AI.', createdAt: new Date() },
+        { title: 'Kubernetes Update', topic: 'DevOps', summary: 'K8s 1.31 released.', createdAt: new Date() }
+      ]),
+      getArticleTrends: jest.fn().mockResolvedValue([
+        { _id: 'AI', count: 5 },
+        { _id: 'DevOps', count: 3 }
+      ])
+    };
+
+    mockChannelContextService = {
+      getRecentContext: jest.fn().mockReturnValue(
+        '[Alice]: Just deployed the new feature\n[Bob]: Nice, tests passing?'
+      ),
+      isChannelTracked: jest.fn().mockReturnValue(true)
+    };
+
+    mockVoiceProfileService = {
+      getProfile: jest.fn().mockResolvedValue({
+        voiceInstructions: 'Speak casually with tech humor.',
+        vocabulary: ['ngl', 'lowkey'],
+        toneKeywords: ['casual', 'witty']
+      })
+    };
+
+    mockOpenAIClient = {
+      responses: {
+        create: jest.fn().mockResolvedValue({
+          output_text: 'Hey! While you were gone: a couple AI papers dropped, Bob shipped the k8s update, and Alice has been on a deploy streak. The usual chaos.',
+          usage: { input_tokens: 500, output_tokens: 100 }
+        })
+      }
+    };
+
+    mockConfig = {
+      openai: { model: 'gpt-4.1-mini' }
+    };
+
+    service = new CatchMeUpService(
+      mockMongoService,
+      mockChannelContextService,
+      mockVoiceProfileService,
+      mockOpenAIClient,
+      mockConfig
+    );
+  });
+
+  describe('generateCatchUp', () => {
+    it('should gather data and return a synthesized catch-up message', async () => {
+      const result = await service.generateCatchUp('user123', 'guild456');
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('While you were gone');
+      expect(mockMongoService.getUserLastSeen).toHaveBeenCalledWith('user123', 'guild456');
+      expect(mockMongoService.getRecentArticleSummaries).toHaveBeenCalled();
+      expect(mockOpenAIClient.responses.create).toHaveBeenCalled();
+    });
+
+    it('should use voice profile for styling when available', async () => {
+      await service.generateCatchUp('user123', 'guild456');
+
+      const callArgs = mockOpenAIClient.responses.create.mock.calls[0][0];
+      expect(callArgs.instructions).toContain('casual');
+    });
+
+    it('should fall back to default style when voice profile unavailable', async () => {
+      mockVoiceProfileService.getProfile.mockResolvedValue(null);
+
+      const result = await service.generateCatchUp('user123', 'guild456');
+
+      expect(result.success).toBe(true);
+      expect(mockOpenAIClient.responses.create).toHaveBeenCalled();
+    });
+
+    it('should use default lookback when no last-seen record exists', async () => {
+      mockMongoService.getUserLastSeen.mockResolvedValue(null);
+
+      const result = await service.generateCatchUp('user123', 'guild456');
+
+      expect(result.success).toBe(true);
+      // Should still fetch articles with a default time range
+      expect(mockMongoService.getRecentArticleSummaries).toHaveBeenCalled();
+    });
+
+    it('should include recent messages from active channels', async () => {
+      await service.generateCatchUp('user123', 'guild456');
+
+      expect(mockChannelContextService.getRecentContext).toHaveBeenCalled();
+    });
+
+    it('should include article trends in the context', async () => {
+      await service.generateCatchUp('user123', 'guild456');
+
+      const callArgs = mockOpenAIClient.responses.create.mock.calls[0][0];
+      expect(callArgs.input).toContain('AI');
+      expect(callArgs.input).toContain('DevOps');
+    });
+
+    it('should handle errors gracefully', async () => {
+      mockOpenAIClient.responses.create.mockRejectedValue(new Error('API Error'));
+
+      const result = await service.generateCatchUp('user123', 'guild456');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('error');
+    });
+
+    it('should return message about nothing to catch up on when no data', async () => {
+      mockMongoService.getRecentArticleSummaries.mockResolvedValue([]);
+      mockMongoService.getArticleTrends.mockResolvedValue([]);
+      mockChannelContextService.getRecentContext.mockReturnValue('');
+
+      const result = await service.generateCatchUp('user123', 'guild456');
+
+      expect(result.success).toBe(true);
+      expect(result.nothingNew).toBe(true);
+    });
+  });
+});

--- a/__tests__/services/MongoService.test.js
+++ b/__tests__/services/MongoService.test.js
@@ -779,4 +779,112 @@ describe('MongoService', () => {
       });
     });
   });
+
+  describe('catch-me-up data methods', () => {
+    describe('getRecentArticleSummaries', () => {
+      it('should return recent article summaries within time range', async () => {
+        const mockArticles = [
+          { url: 'https://example.com/1', title: 'Article 1', topic: 'Tech', summary: 'Summary 1', createdAt: new Date() },
+          { url: 'https://example.com/2', title: 'Article 2', topic: 'Science', summary: 'Summary 2', createdAt: new Date() }
+        ];
+
+        const articlesCollection = {
+          find: jest.fn().mockReturnValue({
+            sort: jest.fn().mockReturnValue({
+              limit: jest.fn().mockReturnValue({
+                toArray: jest.fn().mockResolvedValue(mockArticles)
+              })
+            })
+          })
+        };
+        mongoService.db.collection.mockReturnValue(articlesCollection);
+
+        const result = await mongoService.getRecentArticleSummaries(7);
+
+        expect(mongoService.db.collection).toHaveBeenCalledWith('articles');
+        expect(result).toEqual(mockArticles);
+        expect(articlesCollection.find).toHaveBeenCalledWith(
+          expect.objectContaining({
+            createdAt: expect.objectContaining({ $gte: expect.any(Date) })
+          })
+        );
+      });
+
+      it('should return empty array if db is not connected', async () => {
+        mongoService.db = null;
+        const result = await mongoService.getRecentArticleSummaries(7);
+        expect(result).toEqual([]);
+      });
+    });
+
+    describe('recordUserActivity', () => {
+      it('should upsert user activity record', async () => {
+        const activityCollection = {
+          updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 })
+        };
+        mongoService.db.collection.mockReturnValue(activityCollection);
+
+        await mongoService.recordUserActivity('user123', 'guild456', 'channel789');
+
+        expect(mongoService.db.collection).toHaveBeenCalledWith('user_activity');
+        expect(activityCollection.updateOne).toHaveBeenCalledWith(
+          { userId: 'user123', guildId: 'guild456' },
+          expect.objectContaining({
+            $set: expect.objectContaining({
+              userId: 'user123',
+              guildId: 'guild456',
+              lastSeenAt: expect.any(Date)
+            }),
+            $addToSet: { activeChannels: 'channel789' }
+          }),
+          { upsert: true }
+        );
+      });
+
+      it('should not throw if db is not connected', async () => {
+        mongoService.db = null;
+        await expect(mongoService.recordUserActivity('user123', 'guild456', 'channel789')).resolves.not.toThrow();
+      });
+    });
+
+    describe('getUserLastSeen', () => {
+      it('should return user activity record', async () => {
+        const mockActivity = {
+          userId: 'user123',
+          guildId: 'guild456',
+          lastSeenAt: new Date('2026-04-09'),
+          activeChannels: ['channel1', 'channel2']
+        };
+
+        const activityCollection = {
+          findOne: jest.fn().mockResolvedValue(mockActivity)
+        };
+        mongoService.db.collection.mockReturnValue(activityCollection);
+
+        const result = await mongoService.getUserLastSeen('user123', 'guild456');
+
+        expect(result).toEqual(mockActivity);
+        expect(activityCollection.findOne).toHaveBeenCalledWith({
+          userId: 'user123',
+          guildId: 'guild456'
+        });
+      });
+
+      it('should return null if no record exists', async () => {
+        const activityCollection = {
+          findOne: jest.fn().mockResolvedValue(null)
+        };
+        mongoService.db.collection.mockReturnValue(activityCollection);
+
+        const result = await mongoService.getUserLastSeen('newuser', 'guild456');
+        expect(result).toBeNull();
+      });
+
+      it('should return null if db is not connected', async () => {
+        mongoService.db = null;
+        const result = await mongoService.getUserLastSeen('user123', 'guild456');
+        expect(result).toBeNull();
+      });
+    });
+  });
 });

--- a/bot.js
+++ b/bot.js
@@ -26,6 +26,7 @@ const QdrantService = require('./services/QdrantService');
 const NickMappingService = require('./services/NickMappingService');
 const ChannelContextService = require('./services/ChannelContextService');
 const ImagePromptAnalyzerService = require('./services/ImagePromptAnalyzerService');
+const CatchMeUpService = require('./services/CatchMeUpService');
 const ImageRetryHandler = require('./handlers/ImageRetryHandler');
 const TextUtils = require('./utils/textUtils');
 const localLlmService = require('./services/LocalLlmService');
@@ -51,6 +52,7 @@ const {
   RecallSlashCommand,
   HistorySlashCommand,
   ThrowbackSlashCommand,
+  CatchMeUpSlashCommand,
   HelpSlashCommand,
   ContextSlashCommand,
   ChannelTrackSlashCommand
@@ -240,9 +242,15 @@ class DiscordBot {
       logger.info('Local LLM (uncensored mode) is disabled');
     }
 
-    // Initialize slash command handler
-    // this.commandHandler = new CommandHandler();
-    // this.registerCommands();
+    // Initialize catch-me-up service
+    this.catchMeUpService = new CatchMeUpService(
+      this.summarizationService.mongoService,
+      this.channelContextService,
+      this.voiceProfileService,
+      this.openaiClient,
+      config
+    );
+
     // Initialize slash command handler
     this.slashCommandHandler = new SlashCommandHandler(config);
     this.registerSlashCommands();
@@ -369,6 +377,9 @@ class DiscordBot {
       logger.info('IRC history slash commands registered');
     }
 
+    // Register catch-me-up command
+    this.slashCommandHandler.register(new CatchMeUpSlashCommand(this.catchMeUpService));
+
     logger.info(`Registered ${this.slashCommandHandler.size} slash commands`);
   }
 
@@ -467,6 +478,13 @@ class DiscordBot {
 
     this.client.on('messageCreate', async message => {
       if (message.author.bot) return;
+
+      // Track user activity for catch-me-up (non-blocking)
+      if (message.guild && this.summarizationService?.mongoService) {
+        this.summarizationService.mongoService.recordUserActivity(
+          message.author.id, message.guild.id, message.channel.id
+        ).catch(err => logger.debug(`User activity tracking failed: ${err.message}`));
+      }
 
       // Passive channel context recording (non-blocking)
       if (this.channelContextService?.isChannelTracked(message.channel.id)) {

--- a/commands/slash/CatchMeUpCommand.js
+++ b/commands/slash/CatchMeUpCommand.js
@@ -1,0 +1,70 @@
+// commands/slash/CatchMeUpCommand.js
+// Slash command to get a DM summary of what happened while the user was away
+
+const { SlashCommandBuilder } = require('discord.js');
+const BaseSlashCommand = require('../base/BaseSlashCommand');
+const logger = require('../../logger');
+
+class CatchMeUpSlashCommand extends BaseSlashCommand {
+  constructor(catchMeUpService) {
+    super({
+      data: new SlashCommandBuilder()
+        .setName('catchmeup')
+        .setDescription('Get a DM summary of what you missed while you were away'),
+      deferReply: true,
+      cooldown: 60 // 1 minute cooldown to prevent spam
+    });
+
+    this.catchMeUpService = catchMeUpService;
+  }
+
+  async execute(interaction, context) {
+    this.logExecution(interaction);
+
+    const userId = interaction.user.id;
+    const guildId = interaction.guild?.id || null;
+
+    const result = await this.catchMeUpService.generateCatchUp(userId, guildId);
+
+    if (!result.success) {
+      await this.sendReply(interaction, {
+        content: result.error || 'Failed to generate catch-up summary.',
+        ephemeral: true
+      });
+      return;
+    }
+
+    // If nothing new, reply in channel
+    if (result.nothingNew) {
+      await this.sendReply(interaction, {
+        content: result.message,
+        ephemeral: true
+      });
+      return;
+    }
+
+    // Send catch-up via DM
+    try {
+      await interaction.user.send(result.message);
+
+      await this.sendReply(interaction, {
+        content: "I've sent you a DM with your catch-up summary!",
+        ephemeral: true
+      });
+    } catch (dmError) {
+      logger.warn(`Failed to DM user ${userId}: ${dmError.message}`);
+      await this.sendReply(interaction, {
+        content: "I couldn't send you a DM — you may have DMs disabled for this server. Here's your catch-up instead:",
+        ephemeral: true
+      });
+
+      // Fall back to ephemeral reply in channel
+      await interaction.followUp({
+        content: result.message,
+        ephemeral: true
+      });
+    }
+  }
+}
+
+module.exports = CatchMeUpSlashCommand;

--- a/commands/slash/HelpCommand.js
+++ b/commands/slash/HelpCommand.js
@@ -45,7 +45,8 @@ class HelpSlashCommand extends BaseSlashCommand {
         '`/chatthread` - Start a dedicated conversation thread',
         '`/chatlist` - View your resumable conversations',
         '`/chatresume` - Resume an expired conversation',
-        '`/chatreset` - Reset conversation history (admin)'
+        '`/chatreset` - Reset conversation history (admin)',
+        '`/catchmeup` - Get a DM summary of what you missed'
       ].join('\n'),
       inline: false
     });

--- a/commands/slash/index.js
+++ b/commands/slash/index.js
@@ -27,6 +27,9 @@ module.exports = {
   HistorySlashCommand: require('./HistoryCommand'),
   ThrowbackSlashCommand: require('./ThrowbackCommand'),
 
+  // Activity commands
+  CatchMeUpSlashCommand: require('./CatchMeUpCommand'),
+
   // Utility commands
   HelpSlashCommand: require('./HelpCommand'),
   ContextSlashCommand: require('./ContextCommand'),

--- a/features.md
+++ b/features.md
@@ -27,6 +27,7 @@
 - **Image Vision**: Attach images to chat messages for analysis and discussion
 - **Web Search**: Bot can search the web for current information when needed
 - **Per-user Token Tracking**: Usage recorded per user
+- **Catch Me Up**: `/catchmeup` sends a DM summarizing what happened while you were away — articles, trends, and chat highlights from channels you've been active in, styled in the group's voice
 
 ### Conversation Memory
 - **Channel-Scoped Memory**: All users in a channel share a conversation with each personality

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-article-archiver-bot",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "license": "MIT",
   "description": "A Discord bot that integrates with Linkwarden for self-hosted article archiving and uses OpenAI-compatible APIs to automatically generate summaries of archived articles with support for authenticated/paywalled content.",
   "main": "bot.js",

--- a/services/CatchMeUpService.js
+++ b/services/CatchMeUpService.js
@@ -1,0 +1,138 @@
+// services/CatchMeUpService.js
+// Synthesizes a "catch me up" summary of what happened while a user was away
+
+const logger = require('../logger');
+
+// Default lookback when no last-seen record exists (3 days)
+const DEFAULT_LOOKBACK_DAYS = 3;
+
+class CatchMeUpService {
+  /**
+   * @param {Object} mongoService - MongoService for articles, trends, user activity
+   * @param {Object} channelContextService - ChannelContextService for recent Discord messages
+   * @param {Object} voiceProfileService - VoiceProfileService for channel voice styling
+   * @param {Object} openaiClient - OpenAI client for synthesis
+   * @param {Object} config - Bot configuration
+   */
+  constructor(mongoService, channelContextService, voiceProfileService, openaiClient, config) {
+    this.mongoService = mongoService;
+    this.channelContextService = channelContextService;
+    this.voiceProfileService = voiceProfileService;
+    this.openaiClient = openaiClient;
+    this.config = config;
+  }
+
+  /**
+   * Generate a catch-up summary for a user
+   * @param {string} userId - Discord user ID
+   * @param {string} guildId - Discord guild ID
+   * @returns {Promise<{success: boolean, message?: string, nothingNew?: boolean, error?: string}>}
+   */
+  async generateCatchUp(userId, guildId) {
+    try {
+      // 1. Determine time range
+      const lastSeen = await this.mongoService.getUserLastSeen(userId, guildId);
+      const lookbackDays = lastSeen
+        ? Math.max(1, Math.ceil((Date.now() - new Date(lastSeen.lastSeenAt).getTime()) / (1000 * 60 * 60 * 24)))
+        : DEFAULT_LOOKBACK_DAYS;
+      const activeChannels = lastSeen?.activeChannels || [];
+
+      logger.info(`Generating catch-up for user ${userId}: lookback ${lookbackDays} days, ${activeChannels.length} active channels`);
+
+      // 2. Gather data in parallel
+      const [articles, trends, voiceProfile] = await Promise.all([
+        this.mongoService.getRecentArticleSummaries(lookbackDays),
+        this.mongoService.getArticleTrends(lookbackDays),
+        this.voiceProfileService?.getProfile().catch(() => null) || Promise.resolve(null)
+      ]);
+
+      // 3. Gather recent messages from active channels
+      const channelContexts = [];
+      for (const channelId of activeChannels.slice(0, 5)) { // Cap at 5 channels
+        if (this.channelContextService?.isChannelTracked(channelId)) {
+          const context = this.channelContextService.getRecentContext(channelId, 15);
+          if (context) {
+            channelContexts.push({ channelId, context });
+          }
+        }
+      }
+
+      // 4. Check if there's anything to report
+      const hasArticles = articles.length > 0;
+      const hasTrends = trends.length > 0;
+      const hasMessages = channelContexts.some(c => c.context.length > 0);
+
+      if (!hasArticles && !hasTrends && !hasMessages) {
+        return {
+          success: true,
+          nothingNew: true,
+          message: "Things have been pretty quiet — nothing notable since you were last around."
+        };
+      }
+
+      // 5. Build context for synthesis
+      const contextParts = [];
+
+      if (hasArticles) {
+        const articleList = articles.slice(0, 10).map(a =>
+          `- "${a.title}" (${a.topic || 'General'}): ${a.summary?.substring(0, 150) || 'No summary'}...`
+        ).join('\n');
+        contextParts.push(`**Recent Articles (${articles.length} total):**\n${articleList}`);
+      }
+
+      if (hasTrends) {
+        const trendList = trends.map(t => `${t._id}: ${t.count} articles`).join(', ');
+        contextParts.push(`**Trending Topics:** ${trendList}`);
+      }
+
+      if (hasMessages) {
+        for (const { context } of channelContexts) {
+          contextParts.push(`**Recent Chat:**\n${context}`);
+        }
+      }
+
+      const gatheredContext = contextParts.join('\n\n');
+
+      // 6. Build system prompt with voice styling
+      let systemPrompt = `You are summarizing what happened in a Discord server while a user was away (approximately ${lookbackDays} day${lookbackDays !== 1 ? 's' : ''}).
+
+Your task:
+- Provide a concise, engaging summary of what the user missed
+- Highlight the most interesting articles, discussions, and trends
+- Keep it under 500 words
+- Use a natural, conversational tone — like a friend filling someone in
+- Group related items together rather than listing everything chronologically
+- If there are many articles, highlight the 3-5 most notable ones, not all of them`;
+
+      if (voiceProfile) {
+        systemPrompt += `\n\nStyle your response to match this group's communication style:\n${voiceProfile.voiceInstructions || ''}`;
+        if (voiceProfile.toneKeywords?.length > 0) {
+          systemPrompt += `\nTone: ${voiceProfile.toneKeywords.join(', ')}`;
+        }
+      }
+
+      // 7. Synthesize
+      const response = await this.openaiClient.responses.create({
+        model: this.config.openai.model || 'gpt-4.1-mini',
+        instructions: systemPrompt,
+        input: gatheredContext
+      });
+
+      logger.info(`Catch-up generated for user ${userId}: ${response.usage?.output_tokens || 0} tokens`);
+
+      return {
+        success: true,
+        message: response.output_text.trim()
+      };
+
+    } catch (error) {
+      logger.error(`Error generating catch-up for user ${userId}: ${error.message}`);
+      return {
+        success: false,
+        error: `Sorry, I encountered an error generating your catch-up: ${error.message}`
+      };
+    }
+  }
+}
+
+module.exports = CatchMeUpService;

--- a/services/MongoService.js
+++ b/services/MongoService.js
@@ -1230,6 +1230,76 @@ class MongoService {
             return null;
         }
     }
+    // ==================== CATCH ME UP ====================
+
+    /**
+     * Get recent article summaries within a time range
+     * @param {number} days - Number of days to look back
+     * @param {number} limit - Maximum number of articles to return
+     * @returns {Promise<Array>} Recent articles with summaries
+     */
+    async getRecentArticleSummaries(days = 7, limit = 20) {
+        if (!this.db) {
+            logger.error('Cannot get recent articles: Not connected to MongoDB.');
+            return [];
+        }
+        try {
+            const collection = this.db.collection('articles');
+            const cutoff = new Date();
+            cutoff.setDate(cutoff.getDate() - days);
+
+            return await collection.find({
+                createdAt: { $gte: cutoff }
+            }).sort({ createdAt: -1 }).limit(limit).toArray();
+        } catch (error) {
+            logger.error(`Error getting recent article summaries: ${error.message}`);
+            return [];
+        }
+    }
+
+    /**
+     * Record user activity for last-seen tracking
+     * @param {string} userId - Discord user ID
+     * @param {string} guildId - Discord guild ID
+     * @param {string} channelId - Discord channel ID where activity occurred
+     */
+    async recordUserActivity(userId, guildId, channelId) {
+        if (!this.db) return;
+        try {
+            const collection = this.db.collection('user_activity');
+            await collection.updateOne(
+                { userId, guildId },
+                {
+                    $set: {
+                        userId,
+                        guildId,
+                        lastSeenAt: new Date()
+                    },
+                    $addToSet: { activeChannels: channelId }
+                },
+                { upsert: true }
+            );
+        } catch (error) {
+            logger.error(`Error recording user activity: ${error.message}`);
+        }
+    }
+
+    /**
+     * Get user's last seen activity record
+     * @param {string} userId - Discord user ID
+     * @param {string} guildId - Discord guild ID
+     * @returns {Promise<Object|null>} User activity record or null
+     */
+    async getUserLastSeen(userId, guildId) {
+        if (!this.db) return null;
+        try {
+            const collection = this.db.collection('user_activity');
+            return await collection.findOne({ userId, guildId });
+        } catch (error) {
+            logger.error(`Error getting user last seen: ${error.message}`);
+            return null;
+        }
+    }
 }
 
 module.exports = MongoService;

--- a/users.md
+++ b/users.md
@@ -56,6 +56,7 @@ Just type `/chat message:Hello!` to start chatting.
 | `/chatlist` | List your resumable conversations |
 | `/chatresume message:<text>` | Resume an expired conversation |
 | `/chatreset` | Reset conversation history (admin only) |
+| `/catchmeup` | Get a DM summary of what you missed |
 
 ### Conversation Memory
 
@@ -182,6 +183,7 @@ React to a bot's summary message with the 📚 (books) emoji to mark that articl
 | `/chatlist` | List resumable conversations |
 | `/chatresume message:<msg>` | Resume expired conversation |
 | `/chatreset` | Reset conversation (admin) |
+| `/catchmeup` | DM summary of what you missed |
 | `/imagine prompt:<text>` | Generate an image |
 | `/videogen prompt:<text>` | Generate a video |
 | `/memories` | View your memories |


### PR DESCRIPTION
## Summary
New agentic feature: `/catchmeup` sends the user a DM summarizing what they missed while away.

**How it works:**
1. Tracks per-user activity timestamps via non-blocking `recordUserActivity()` on every message
2. On `/catchmeup`, calculates how long the user has been away
3. Gathers data in parallel: recent articles, trending topics, chat highlights from the user's active channels
4. Synthesizes a natural catch-up message using the channel voice profile for tone
5. Sends via DM (falls back to ephemeral reply if DMs are disabled)

**New components:**
- `CatchMeUpService` — orchestrates data gathering and LLM synthesis
- `CatchMeUpCommand` — `/catchmeup` slash command
- `MongoService.getRecentArticleSummaries()` — time-range article query
- `MongoService.recordUserActivity()` / `getUserLastSeen()` — per-user activity tracking

Stacked on #62 (feat/imagegen-auto-retry).

## Test plan
- [x] 8 tests for CatchMeUpService
- [x] 6 tests for CatchMeUpCommand
- [x] 7 tests for new MongoService methods
- [x] Full suite passes (671 tests, 23 suites)
- [x] Deployed to k8s as v2.10.0
- [ ] Run `/catchmeup` in Discord and verify DM is received
- [ ] Note: activity tracking starts now — first catch-ups may have limited data

🤖 Generated with [Claude Code](https://claude.com/claude-code)