### PR TITLE
fix: split catch-me-up messages exceeding Discord limit

### DIFF
--- a/__tests__/commands/slash/CatchMeUpCommand.test.js
+++ b/__tests__/commands/slash/CatchMeUpCommand.test.js
@@ -97,6 +97,23 @@ describe('CatchMeUpSlashCommand', () => {
       );
     });
 
+    it('should split long messages into chunks for DM', async () => {
+      const longMessage = 'A'.repeat(3000);
+      mockCatchMeUpService.generateCatchUp.mockResolvedValue({
+        success: true,
+        message: longMessage
+      });
+
+      await command.execute(mockInteraction, {});
+
+      // Should have sent multiple DMs
+      expect(mockInteraction.user.send).toHaveBeenCalledTimes(2);
+      // Each chunk should be <= 2000 chars
+      mockInteraction.user.send.mock.calls.forEach(call => {
+        expect(call[0].length).toBeLessThanOrEqual(2000);
+      });
+    });
+
     it('should handle service errors gracefully', async () => {
       mockCatchMeUpService.generateCatchUp.mockResolvedValue({
         success: false,

--- a/commands/slash/CatchMeUpCommand.js
+++ b/commands/slash/CatchMeUpCommand.js
@@ -43,9 +43,14 @@ class CatchMeUpSlashCommand extends BaseSlashCommand {
       return;
     }
 
+    // Split long messages into Discord-safe chunks
+    const chunks = this.splitMessage(result.message, 2000);
+
     // Send catch-up via DM
     try {
-      await interaction.user.send(result.message);
+      for (const chunk of chunks) {
+        await interaction.user.send(chunk);
+      }
 
       await this.sendReply(interaction, {
         content: "I've sent you a DM with your catch-up summary!",
@@ -58,11 +63,13 @@ class CatchMeUpSlashCommand extends BaseSlashCommand {
         ephemeral: true
       });
 
-      // Fall back to ephemeral reply in channel
-      await interaction.followUp({
-        content: result.message,
-        ephemeral: true
-      });
+      // Fall back to ephemeral replies in channel
+      for (const chunk of chunks) {
+        await interaction.followUp({
+          content: chunk,
+          ephemeral: true
+        });
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-article-archiver-bot",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "license": "MIT",
   "description": "A Discord bot that integrates with Linkwarden for self-hosted article archiving and uses OpenAI-compatible APIs to automatically generate summaries of archived articles with support for authenticated/paywalled content.",
   "main": "bot.js",


### PR DESCRIPTION
## Summary
- DM and ephemeral fallback now split long messages into 2000-char chunks before sending
- Fixes `DiscordAPIError[50035]: Must be 2000 or fewer in length` on verbose catch-ups

Stacked on #63.

## Test plan
- [x] New test for chunked DM delivery
- [x] Full suite passes (672 tests)
- [x] Deployed as v2.10.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)