### PR TITLE
fix: prevent catch-me-up hallucination with strict grounding

### DIFF
--- a/__tests__/services/CatchMeUpService.test.js
+++ b/__tests__/services/CatchMeUpService.test.js
@@ -108,6 +108,16 @@ describe('CatchMeUpService', () => {
       expect(mockChannelContextService.getRecentContext).toHaveBeenCalled();
     });
 
+    it('should skip LLM call when context is too thin', async () => {
+      mockChannelContextService.getRecentContext.mockReturnValue('[Alice]: hi');
+
+      const result = await service.generateCatchUp('user123', 'guild456');
+
+      expect(result.success).toBe(true);
+      expect(result.nothingNew).toBe(true);
+      expect(mockOpenAIClient.responses.create).not.toHaveBeenCalled();
+    });
+
     it('should use explicit days parameter when provided', async () => {
       const result = await service.generateCatchUp('user123', 'guild456', { days: 7 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.10.6",
+  "version": "2.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-article-archiver-bot",
-      "version": "2.10.6",
+      "version": "2.10.7",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.10.6",
+  "version": "2.10.7",
   "license": "MIT",
   "description": "A Discord bot that integrates with Linkwarden for self-hosted article archiving and uses OpenAI-compatible APIs to automatically generate summaries of archived articles with support for authenticated/paywalled content.",
   "main": "bot.js",

--- a/services/CatchMeUpService.js
+++ b/services/CatchMeUpService.js
@@ -92,16 +92,32 @@ class CatchMeUpService {
 
       const gatheredContext = contextParts.join('\n\n');
 
+      // Guard: if context is too thin, don't waste an LLM call on it
+      const contextLines = gatheredContext.split('\n').filter(l => l.trim() && !l.startsWith('**')).length;
+      if (contextLines < 3) {
+        logger.info(`Catch-up context too thin (${contextLines} lines), skipping LLM synthesis`);
+        return {
+          success: true,
+          nothingNew: true,
+          message: "Things have been pretty quiet — not enough recent conversation to summarize."
+        };
+      }
+
       // 6. Build system prompt with voice styling
       let systemPrompt = `You are summarizing what happened in a Discord server while a user was away (approximately ${lookbackLabel}).
 
+CRITICAL RULES:
+- ONLY reference conversations, users, and events that appear in the provided chat logs below
+- Do NOT invent, fabricate, or hallucinate any content, usernames, events, or discussions
+- If the chat logs are sparse, keep the summary short — a few sentences is fine
+- It is much better to say "not much happened" than to make things up
+- Only mention usernames that explicitly appear in the [Username]: format in the logs
+
 Your task:
-- Provide a concise, engaging summary of what the user missed
-- Highlight the most interesting articles, discussions, and trends
-- Keep it under 500 words
-- Use a natural, conversational tone — like a friend filling someone in
-- Group related items together rather than listing everything chronologically
-- If there are many articles, highlight the 3-5 most notable ones, not all of them`;
+- Summarize what actually happened based on the chat logs provided
+- Keep it concise and natural — like a friend filling someone in
+- Group related topics together
+- If there's very little to report, just say so briefly`;
 
       if (voiceProfile) {
         systemPrompt += `\n\nStyle your response to match this group's communication style:\n${voiceProfile.voiceInstructions || ''}`;
@@ -111,13 +127,17 @@ Your task:
       }
 
       // 7. Synthesize
+      logger.info(`Catch-up LLM input for user ${userId}: ${contextLines} context lines, ${gatheredContext.length} chars`);
+      logger.debug(`Catch-up raw context:\n${gatheredContext}`);
+
       const response = await this.openaiClient.responses.create({
         model: this.config.openai.model || 'gpt-4.1-mini',
         instructions: systemPrompt,
         input: gatheredContext
       });
 
-      logger.info(`Catch-up generated for user ${userId}: ${response.usage?.output_tokens || 0} tokens`);
+      logger.info(`Catch-up generated for user ${userId}: ${response.usage?.input_tokens || 0} input tokens, ${response.usage?.output_tokens || 0} output tokens`);
+      logger.debug(`Catch-up LLM output:\n${response.output_text}`);
 
       return {
         success: true,


### PR DESCRIPTION
## Summary
- Strict anti-hallucination rules in system prompt: LLM can only reference content explicitly in the provided chat logs
- Minimum context threshold: skip LLM entirely if fewer than 3 message lines
- Input/output logging at info and debug levels for Dynatrace traceability

## Test plan
- [x] New test for thin context guard
- [x] Full suite passes (678 tests)
- [x] Deployed as v2.10.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)