### PR TITLE
feat: persist channel messages to MongoDB for catch-me-up

### DIFF
--- a/__tests__/services/CatchMeUpService.test.js
+++ b/__tests__/services/CatchMeUpService.test.js
@@ -26,20 +26,13 @@ describe('CatchMeUpService', () => {
         guildId: 'guild456',
         lastSeenAt: new Date('2026-04-08T00:00:00Z'),
         activeChannels: ['channel1', 'channel2']
-      })
-    };
-
-    mockChannelContextService = {
-      getRecentContext: jest.fn().mockReturnValue(
-        '[Alice]: Just deployed the new feature\n[Bob]: Nice, tests passing?'
-      ),
-      getRecentMessagesFromStore: jest.fn().mockResolvedValue([
-        { authorName: 'Alice', content: 'Just deployed the new feature', timestamp: new Date().toISOString() },
-        { authorName: 'Bob', content: 'Nice, tests passing?', timestamp: new Date().toISOString() },
-        { authorName: 'Alice', content: 'All green', timestamp: new Date().toISOString() },
-        { authorName: 'Charlie', content: 'Ship it', timestamp: new Date().toISOString() }
-      ]),
-      isChannelTracked: jest.fn().mockReturnValue(true)
+      }),
+      getChannelMessages: jest.fn().mockResolvedValue([
+        { authorName: 'Alice', content: 'Just deployed the new feature', timestamp: new Date() },
+        { authorName: 'Bob', content: 'Nice, tests passing?', timestamp: new Date() },
+        { authorName: 'Alice', content: 'All green', timestamp: new Date() },
+        { authorName: 'Charlie', content: 'Ship it', timestamp: new Date() }
+      ])
     };
 
     mockVoiceProfileService = {
@@ -65,7 +58,6 @@ describe('CatchMeUpService', () => {
 
     service = new CatchMeUpService(
       mockMongoService,
-      mockChannelContextService,
       mockVoiceProfileService,
       mockOpenAIClient,
       mockConfig
@@ -108,25 +100,20 @@ describe('CatchMeUpService', () => {
       expect(result.nothingNew).toBe(true);
     });
 
-    it('should fetch messages from persisted store for active channels', async () => {
+    it('should fetch messages from MongoDB for active channels', async () => {
       await service.generateCatchUp('user123', 'guild456');
 
-      expect(mockChannelContextService.getRecentMessagesFromStore).toHaveBeenCalled();
-    });
-
-    it('should fall back to in-memory buffer when store is empty', async () => {
-      mockChannelContextService.getRecentMessagesFromStore.mockResolvedValue([]);
-
-      await service.generateCatchUp('user123', 'guild456');
-
-      expect(mockChannelContextService.getRecentContext).toHaveBeenCalled();
+      expect(mockMongoService.getChannelMessages).toHaveBeenCalledWith(
+        ['channel1', 'channel2'],
+        expect.any(Date),
+        200
+      );
     });
 
     it('should skip LLM call when context is too thin', async () => {
-      mockChannelContextService.getRecentMessagesFromStore.mockResolvedValue([
-        { authorName: 'Alice', content: 'hi', timestamp: new Date().toISOString() }
+      mockMongoService.getChannelMessages.mockResolvedValue([
+        { authorName: 'Alice', content: 'hi', timestamp: new Date() }
       ]);
-      mockChannelContextService.getRecentContext.mockReturnValue('[Alice]: hi');
 
       const result = await service.generateCatchUp('user123', 'guild456');
 
@@ -151,9 +138,8 @@ describe('CatchMeUpService', () => {
       expect(result.error).toContain('error');
     });
 
-    it('should return nothing new when no chat context available', async () => {
-      mockChannelContextService.getRecentMessagesFromStore.mockResolvedValue([]);
-      mockChannelContextService.getRecentContext.mockReturnValue('');
+    it('should return nothing new when no messages in MongoDB', async () => {
+      mockMongoService.getChannelMessages.mockResolvedValue([]);
 
       const result = await service.generateCatchUp('user123', 'guild456');
 

--- a/__tests__/services/CatchMeUpService.test.js
+++ b/__tests__/services/CatchMeUpService.test.js
@@ -33,6 +33,12 @@ describe('CatchMeUpService', () => {
       getRecentContext: jest.fn().mockReturnValue(
         '[Alice]: Just deployed the new feature\n[Bob]: Nice, tests passing?'
       ),
+      getRecentMessagesFromStore: jest.fn().mockResolvedValue([
+        { authorName: 'Alice', content: 'Just deployed the new feature', timestamp: new Date().toISOString() },
+        { authorName: 'Bob', content: 'Nice, tests passing?', timestamp: new Date().toISOString() },
+        { authorName: 'Alice', content: 'All green', timestamp: new Date().toISOString() },
+        { authorName: 'Charlie', content: 'Ship it', timestamp: new Date().toISOString() }
+      ]),
       isChannelTracked: jest.fn().mockReturnValue(true)
     };
 
@@ -102,13 +108,24 @@ describe('CatchMeUpService', () => {
       expect(result.nothingNew).toBe(true);
     });
 
-    it('should include recent messages from active channels', async () => {
+    it('should fetch messages from persisted store for active channels', async () => {
+      await service.generateCatchUp('user123', 'guild456');
+
+      expect(mockChannelContextService.getRecentMessagesFromStore).toHaveBeenCalled();
+    });
+
+    it('should fall back to in-memory buffer when store is empty', async () => {
+      mockChannelContextService.getRecentMessagesFromStore.mockResolvedValue([]);
+
       await service.generateCatchUp('user123', 'guild456');
 
       expect(mockChannelContextService.getRecentContext).toHaveBeenCalled();
     });
 
     it('should skip LLM call when context is too thin', async () => {
+      mockChannelContextService.getRecentMessagesFromStore.mockResolvedValue([
+        { authorName: 'Alice', content: 'hi', timestamp: new Date().toISOString() }
+      ]);
       mockChannelContextService.getRecentContext.mockReturnValue('[Alice]: hi');
 
       const result = await service.generateCatchUp('user123', 'guild456');
@@ -135,6 +152,7 @@ describe('CatchMeUpService', () => {
     });
 
     it('should return nothing new when no chat context available', async () => {
+      mockChannelContextService.getRecentMessagesFromStore.mockResolvedValue([]);
       mockChannelContextService.getRecentContext.mockReturnValue('');
 
       const result = await service.generateCatchUp('user123', 'guild456');

--- a/__tests__/services/MongoService.test.js
+++ b/__tests__/services/MongoService.test.js
@@ -886,5 +886,96 @@ describe('MongoService', () => {
         expect(result).toBeNull();
       });
     });
+
+    describe('recordChannelMessage', () => {
+      it('should insert a message document', async () => {
+        const msgCollection = {
+          insertOne: jest.fn().mockResolvedValue({ insertedId: 'msg-id' })
+        };
+        mongoService.db.collection.mockReturnValue(msgCollection);
+
+        await mongoService.recordChannelMessage({
+          messageId: 'msg123',
+          channelId: 'channel456',
+          guildId: 'guild789',
+          authorId: 'user123',
+          authorName: 'Alice',
+          content: 'Hello world',
+          timestamp: new Date()
+        });
+
+        expect(mongoService.db.collection).toHaveBeenCalledWith('channel_messages');
+        expect(msgCollection.insertOne).toHaveBeenCalledWith(
+          expect.objectContaining({
+            messageId: 'msg123',
+            channelId: 'channel456',
+            authorName: 'Alice',
+            content: 'Hello world'
+          })
+        );
+      });
+
+      it('should not throw if db is not connected', async () => {
+        mongoService.db = null;
+        await expect(mongoService.recordChannelMessage({ messageId: 'x' })).resolves.not.toThrow();
+      });
+    });
+
+    describe('getChannelMessages', () => {
+      it('should return messages for a channel since a given time', async () => {
+        const mockMessages = [
+          { authorName: 'Alice', content: 'Hello', timestamp: new Date() },
+          { authorName: 'Bob', content: 'Hi there', timestamp: new Date() }
+        ];
+
+        const msgCollection = {
+          find: jest.fn().mockReturnValue({
+            sort: jest.fn().mockReturnValue({
+              limit: jest.fn().mockReturnValue({
+                toArray: jest.fn().mockResolvedValue(mockMessages)
+              })
+            })
+          })
+        };
+        mongoService.db.collection.mockReturnValue(msgCollection);
+
+        const since = new Date('2026-04-10T00:00:00Z');
+        const result = await mongoService.getChannelMessages('channel456', since, 50);
+
+        expect(mongoService.db.collection).toHaveBeenCalledWith('channel_messages');
+        expect(msgCollection.find).toHaveBeenCalledWith({
+          channelId: 'channel456',
+          timestamp: { $gte: since }
+        });
+        expect(result).toEqual(mockMessages);
+      });
+
+      it('should query multiple channels when array is provided', async () => {
+        const msgCollection = {
+          find: jest.fn().mockReturnValue({
+            sort: jest.fn().mockReturnValue({
+              limit: jest.fn().mockReturnValue({
+                toArray: jest.fn().mockResolvedValue([])
+              })
+            })
+          })
+        };
+        mongoService.db.collection.mockReturnValue(msgCollection);
+
+        await mongoService.getChannelMessages(['ch1', 'ch2'], new Date());
+
+        expect(msgCollection.find).toHaveBeenCalledWith(
+          expect.objectContaining({
+            channelId: { $in: ['ch1', 'ch2'] }
+          })
+        );
+      });
+
+      it('should return empty array if db is not connected', async () => {
+        mongoService.db = null;
+        const result = await mongoService.getChannelMessages('ch1', new Date());
+        expect(result).toEqual([]);
+      });
+    });
   });
 });

--- a/bot.js
+++ b/bot.js
@@ -240,8 +240,7 @@ class DiscordBot {
 
     // Initialize catch-me-up service
     this.catchMeUpService = new CatchMeUpService(
-      this.mongoService, this.channelContextService, this.voiceProfileService,
-      this.openaiClient, config
+      this.mongoService, this.voiceProfileService, this.openaiClient, config
     );
 
     // Initialize slash command handler
@@ -473,14 +472,24 @@ class DiscordBot {
     this.client.on('messageCreate', async message => {
       if (message.author.bot) return;
 
-      // Track user activity for catch-me-up (non-blocking)
+      // Track user activity and persist message for catch-me-up (non-blocking)
       if (message.guild && this.mongoService) {
         this.mongoService.recordUserActivity(
           message.author.id, message.guild.id, message.channel.id
         ).catch(err => logger.debug(`User activity tracking failed: ${err.message}`));
+
+        this.mongoService.recordChannelMessage({
+          messageId: message.id,
+          channelId: message.channel.id,
+          guildId: message.guild.id,
+          authorId: message.author.id,
+          authorName: message.author.username,
+          content: message.content,
+          timestamp: new Date()
+        }).catch(err => logger.debug(`Channel message recording failed: ${err.message}`));
       }
 
-      // Passive channel context recording (non-blocking)
+      // Passive channel context recording for semantic search (non-blocking, writes to Qdrant)
       if (this.channelContextService?.isChannelTracked(message.channel.id)) {
         this.channelContextService.recordMessage(message).catch(err =>
           logger.debug(`Channel context record failed: ${err.message}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.10.7",
+  "version": "2.10.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-article-archiver-bot",
-      "version": "2.10.7",
+      "version": "2.10.8",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.10.8",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-article-archiver-bot",
-      "version": "2.10.8",
+      "version": "2.11.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.10.8",
+  "version": "2.11.0",
   "license": "MIT",
   "description": "A Discord bot that integrates with Linkwarden for self-hosted article archiving and uses OpenAI-compatible APIs to automatically generate summaries of archived articles with support for authenticated/paywalled content.",
   "main": "bot.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.10.7",
+  "version": "2.10.8",
   "license": "MIT",
   "description": "A Discord bot that integrates with Linkwarden for self-hosted article archiving and uses OpenAI-compatible APIs to automatically generate summaries of archived articles with support for authenticated/paywalled content.",
   "main": "bot.js",

--- a/services/CatchMeUpService.js
+++ b/services/CatchMeUpService.js
@@ -60,13 +60,23 @@ class CatchMeUpService {
       const voiceProfile = await (this.voiceProfileService?.getProfile().catch(() => null) || Promise.resolve(null));
 
       // 3. Gather recent messages from active channels
+      // Use both in-memory buffer (hot, survives nothing) and Qdrant store (warm, survives restarts)
+      const since = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000);
       const channelContexts = [];
       for (const channelId of activeChannels.slice(0, 5)) { // Cap at 5 channels
-        if (this.channelContextService?.isChannelTracked(channelId)) {
-          const context = this.channelContextService.getRecentContext(channelId, 15);
-          if (context) {
-            channelContexts.push({ channelId, context });
-          }
+        if (!this.channelContextService?.isChannelTracked(channelId)) continue;
+
+        // Try persisted store first (survives pod restarts), fall back to in-memory
+        let context = '';
+        const storedMessages = await this.channelContextService.getRecentMessagesFromStore(channelId, since, 50);
+        if (storedMessages.length > 0) {
+          context = storedMessages.map(m => `[${m.authorName}]: ${m.content}`).join('\n');
+        } else {
+          context = this.channelContextService.getRecentContext(channelId, 15) || '';
+        }
+
+        if (context) {
+          channelContexts.push({ channelId, context });
         }
       }
 

--- a/services/CatchMeUpService.js
+++ b/services/CatchMeUpService.js
@@ -10,15 +10,13 @@ const MIN_LOOKBACK_HOURS = 1;
 
 class CatchMeUpService {
   /**
-   * @param {Object} mongoService - MongoService for articles, trends, user activity
-   * @param {Object} channelContextService - ChannelContextService for recent Discord messages
+   * @param {Object} mongoService - MongoService for messages, user activity
    * @param {Object} voiceProfileService - VoiceProfileService for channel voice styling
    * @param {Object} openaiClient - OpenAI client for synthesis
    * @param {Object} config - Bot configuration
    */
-  constructor(mongoService, channelContextService, voiceProfileService, openaiClient, config) {
+  constructor(mongoService, voiceProfileService, openaiClient, config) {
     this.mongoService = mongoService;
-    this.channelContextService = channelContextService;
     this.voiceProfileService = voiceProfileService;
     this.openaiClient = openaiClient;
     this.config = config;
@@ -59,24 +57,23 @@ class CatchMeUpService {
       // 2. Gather data in parallel
       const voiceProfile = await (this.voiceProfileService?.getProfile().catch(() => null) || Promise.resolve(null));
 
-      // 3. Gather recent messages from active channels
-      // Use both in-memory buffer (hot, survives nothing) and Qdrant store (warm, survives restarts)
+      // 3. Gather recent messages from MongoDB (persists across restarts)
       const since = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000);
       const channelContexts = [];
-      for (const channelId of activeChannels.slice(0, 5)) { // Cap at 5 channels
-        if (!this.channelContextService?.isChannelTracked(channelId)) continue;
 
-        // Try persisted store first (survives pod restarts), fall back to in-memory
-        let context = '';
-        const storedMessages = await this.channelContextService.getRecentMessagesFromStore(channelId, since, 50);
-        if (storedMessages.length > 0) {
-          context = storedMessages.map(m => `[${m.authorName}]: ${m.content}`).join('\n');
-        } else {
-          context = this.channelContextService.getRecentContext(channelId, 15) || '';
-        }
+      if (activeChannels.length > 0) {
+        const messages = await this.mongoService.getChannelMessages(
+          activeChannels.slice(0, 5), since, 200
+        );
 
-        if (context) {
-          channelContexts.push({ channelId, context });
+        if (messages.length > 0) {
+          const context = messages
+            .filter(m => m.content && m.content.trim())
+            .map(m => `[${m.authorName}]: ${m.content}`)
+            .join('\n');
+          if (context) {
+            channelContexts.push({ context });
+          }
         }
       }
 

--- a/services/ChannelContextService.js
+++ b/services/ChannelContextService.js
@@ -582,6 +582,46 @@ class ChannelContextService {
   }
 
   /**
+   * Get recent messages from Qdrant for a channel within a time range
+   * Unlike getRecentContext (in-memory), this survives pod restarts
+   * @param {string} channelId - Channel ID
+   * @param {Date} since - Start of time range
+   * @param {number} limit - Max messages to return
+   * @returns {Promise<Array<{authorName: string, content: string, timestamp: string}>>}
+   */
+  async getRecentMessagesFromStore(channelId, since, limit = 50) {
+    if (!this._enabled || !this.qdrantClient) return [];
+
+    try {
+      const results = await this.qdrantClient.scroll(this.config.qdrantCollection, {
+        filter: {
+          must: [
+            { key: 'channelId', match: { value: channelId } },
+            { key: 'timestamp', range: { gte: since.toISOString() } }
+          ]
+        },
+        limit,
+        with_payload: true,
+        with_vector: false
+      });
+
+      // Sort by timestamp ascending and format
+      const messages = (results.points || [])
+        .sort((a, b) => new Date(a.payload.timestamp) - new Date(b.payload.timestamp))
+        .map(p => ({
+          authorName: p.payload.authorName,
+          content: p.payload.content,
+          timestamp: p.payload.timestamp
+        }));
+
+      return messages;
+    } catch (error) {
+      logger.error(`Error fetching recent messages from store: ${error.message}`);
+      return [];
+    }
+  }
+
+  /**
    * Cleanup expired messages from Qdrant
    */
   async _cleanupExpiredMessages() {

--- a/services/MongoService.js
+++ b/services/MongoService.js
@@ -53,6 +53,11 @@ class MongoService {
             await this.client.connect();
             this.db = this.client.db('discord');
             logger.info('Successfully connected to MongoDB.');
+
+            // Ensure indexes for time-range queries
+            this.db.collection('channel_messages').createIndex(
+              { channelId: 1, timestamp: 1 }
+            ).catch(err => logger.debug(`Index creation (channel_messages): ${err.message}`));
         } catch (error) {
             logger.error('Error connecting to MongoDB:', error);
         }
@@ -1298,6 +1303,47 @@ class MongoService {
         } catch (error) {
             logger.error(`Error getting user last seen: ${error.message}`);
             return null;
+        }
+    }
+
+    // ==================== CHANNEL MESSAGES ====================
+
+    /**
+     * Record a channel message for historical retrieval
+     * @param {Object} message - Message data
+     */
+    async recordChannelMessage(message) {
+        if (!this.db) return;
+        try {
+            const collection = this.db.collection('channel_messages');
+            await collection.insertOne(message);
+        } catch (error) {
+            logger.error(`Error recording channel message: ${error.message}`);
+        }
+    }
+
+    /**
+     * Get channel messages since a given time
+     * @param {string|string[]} channelIds - Single channel ID or array of channel IDs
+     * @param {Date} since - Start of time range
+     * @param {number} limit - Max messages to return
+     * @returns {Promise<Array>} Messages sorted by timestamp ascending
+     */
+    async getChannelMessages(channelIds, since, limit = 200) {
+        if (!this.db) return [];
+        try {
+            const collection = this.db.collection('channel_messages');
+            const channelFilter = Array.isArray(channelIds)
+                ? { $in: channelIds }
+                : channelIds;
+
+            return await collection.find({
+                channelId: channelFilter,
+                timestamp: { $gte: since }
+            }).sort({ timestamp: 1 }).limit(limit).toArray();
+        } catch (error) {
+            logger.error(`Error getting channel messages: ${error.message}`);
+            return [];
         }
     }
 }


### PR DESCRIPTION
## Summary
- New `channel_messages` MongoDB collection stores all channel messages permanently
- Non-blocking write on every `messageCreate` event (alongside existing Qdrant writes)
- `/catchmeup` now queries MongoDB instead of Qdrant's volatile store — survives pod restarts, supports proper time-range queries
- Compound index `{channelId, timestamp}` for fast lookups
- CatchMeUpService no longer depends on ChannelContextService
- Qdrant `channel_conversations` still written for semantic search capabilities

## Test plan
- [x] 5 new MongoService tests (recordChannelMessage, getChannelMessages with single/multi channel)
- [x] Updated CatchMeUpService tests for MongoDB data source
- [x] Full suite passes (683 tests, 24 suites)
- [x] Deployed as v2.11.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)