### PR TITLE
feat: voice-informed search with query expansion and narrative synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ A Discord bot with AI chat (channel-voice personality), image/video generation, 
 
 ### IRC History Search
 
-- **Semantic Search**: Search through archived IRC conversations using natural language
+- **Voice-Informed Search**: Query expansion using the group's vocabulary — searches for how the group actually talked, not just what you typed
+- **Narrative Summaries**: `/recall query:"topic" summarize:true` returns a voice-styled narrative instead of raw logs
+- **Semantic Search**: Vector similarity search through archived IRC conversations
 - **Discord-to-IRC Mapping**: Links Discord users to their historical IRC nicknames
-- **Personal History**: Filter searches to your own conversations with `--me` flag
-- **Time-Based Filtering**: Filter by year or decade
+- **Personal History**: Filter searches to your own conversations
+- **Time-Based Filtering**: Filter by year
 - **Throwback Feature**: Random conversations from "this day in history"
-- **Graceful Degradation**: Commands hidden when Qdrant service unavailable
 
 ### Additional Features
 

--- a/__tests__/services/VoiceSearchService.test.js
+++ b/__tests__/services/VoiceSearchService.test.js
@@ -1,0 +1,180 @@
+// __tests__/services/VoiceSearchService.test.js
+
+jest.mock('../../logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn()
+}));
+
+const VoiceSearchService = require('../../services/VoiceSearchService');
+
+describe('VoiceSearchService', () => {
+  let service;
+  let mockQdrantService;
+  let mockVoiceProfileService;
+  let mockOpenAIClient;
+  let mockConfig;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockQdrantService = {
+      search: jest.fn().mockResolvedValue([
+        { id: 1, score: 0.85, payload: { text: 'Akira: k8s is down again\nod: not again', participants: ['Akira', 'od'], channel: '#ops', year: 2019, start_time: '2019-03-15T02:00:00' } },
+        { id: 2, score: 0.72, payload: { text: 'od: rolled back the config\nAkira: prod is back', participants: ['od', 'Akira'], channel: '#ops', year: 2019, start_time: '2019-03-15T03:00:00' } }
+      ])
+    };
+
+    mockVoiceProfileService = {
+      getProfile: jest.fn().mockResolvedValue({
+        voiceInstructions: 'Be casual and direct. Use lowercase.',
+        vocabulary: ['k8s', 'kube', 'prod', 'nah', 'lmao'],
+        toneKeywords: ['casual', 'sardonic']
+      })
+    };
+
+    mockOpenAIClient = {
+      responses: {
+        create: jest.fn().mockResolvedValue({
+          output_text: '["k8s outage", "kubernetes went down", "kube crash"]',
+          usage: { input_tokens: 200, output_tokens: 30 }
+        })
+      }
+    };
+
+    mockConfig = {
+      openai: { model: 'gpt-4.1-mini' }
+    };
+
+    service = new VoiceSearchService(
+      mockQdrantService, mockVoiceProfileService, mockOpenAIClient, mockConfig
+    );
+  });
+
+  describe('expandQuery', () => {
+    it('should return expanded queries from LLM', async () => {
+      const result = await service.expandQuery('kubernetes outage');
+
+      expect(result).toContain('k8s outage');
+      expect(result).toContain('kubernetes went down');
+      expect(mockOpenAIClient.responses.create).toHaveBeenCalled();
+    });
+
+    it('should include original query in results', async () => {
+      const result = await service.expandQuery('kubernetes outage');
+
+      expect(result).toContain('kubernetes outage');
+    });
+
+    it('should include vocabulary from voice profile', async () => {
+      await service.expandQuery('kubernetes outage');
+
+      const callArgs = mockOpenAIClient.responses.create.mock.calls[0][0];
+      expect(callArgs.input).toContain('k8s');
+      expect(callArgs.input).toContain('kube');
+    });
+
+    it('should fall back to original query on LLM error', async () => {
+      mockOpenAIClient.responses.create.mockRejectedValue(new Error('API Error'));
+
+      const result = await service.expandQuery('kubernetes outage');
+
+      expect(result).toEqual(['kubernetes outage']);
+    });
+
+    it('should fall back to original query when no voice profile', async () => {
+      mockVoiceProfileService.getProfile.mockResolvedValue(null);
+
+      const result = await service.expandQuery('kubernetes outage');
+
+      // Should still call LLM but without vocabulary context
+      expect(result).toContain('kubernetes outage');
+    });
+  });
+
+  describe('searchWithExpansion', () => {
+    it('should search with multiple expanded queries in parallel', async () => {
+      const results = await service.searchWithExpansion('kubernetes outage', {});
+
+      // Should have called search multiple times (original + expanded variants)
+      expect(mockQdrantService.search.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should deduplicate results by point ID', async () => {
+      // Both queries return the same results
+      mockQdrantService.search.mockResolvedValue([
+        { id: 1, score: 0.85, payload: { text: 'duplicate result' } }
+      ]);
+
+      const results = await service.searchWithExpansion('test query', {});
+
+      // Should deduplicate to 1 result despite 3 queries
+      expect(results.length).toBe(1);
+    });
+
+    it('should keep the highest score for duplicates', async () => {
+      mockQdrantService.search
+        .mockResolvedValueOnce([{ id: 1, score: 0.6, payload: { text: 'test' } }])
+        .mockResolvedValueOnce([{ id: 1, score: 0.9, payload: { text: 'test' } }])
+        .mockResolvedValueOnce([]);
+
+      const results = await service.searchWithExpansion('test', {});
+
+      expect(results[0].score).toBe(0.9);
+    });
+
+    it('should pass search options through to qdrant', async () => {
+      await service.searchWithExpansion('test', { year: 2019, participants: ['Akira'] });
+
+      const callOptions = mockQdrantService.search.mock.calls[0][1];
+      expect(callOptions.year).toBe(2019);
+      expect(callOptions.participants).toEqual(['Akira']);
+    });
+  });
+
+  describe('synthesizeResults', () => {
+    const mockResults = [
+      { id: 1, score: 0.85, payload: { text: 'Akira: k8s is down\nod: fixing it', channel: '#ops', year: 2019, start_time: '2019-03-15T02:00:00' } },
+      { id: 2, score: 0.72, payload: { text: 'od: rolled back\nAkira: we are back', channel: '#ops', year: 2019, start_time: '2019-03-15T03:00:00' } }
+    ];
+
+    beforeEach(() => {
+      mockOpenAIClient.responses.create.mockResolvedValue({
+        output_text: 'yeah that was march 2019, od was on call and Akira was debugging. they rolled back a bad config push around 2am.',
+        usage: { input_tokens: 500, output_tokens: 100 }
+      });
+    });
+
+    it('should synthesize results using voice profile', async () => {
+      const summary = await service.synthesizeResults('kubernetes outage', mockResults);
+
+      expect(summary).toContain('march 2019');
+      const callArgs = mockOpenAIClient.responses.create.mock.calls[0][0];
+      expect(callArgs.instructions).toContain('casual');
+    });
+
+    it('should include search results in LLM input', async () => {
+      await service.synthesizeResults('kubernetes outage', mockResults);
+
+      const callArgs = mockOpenAIClient.responses.create.mock.calls[0][0];
+      expect(callArgs.input).toContain('k8s is down');
+      expect(callArgs.input).toContain('rolled back');
+    });
+
+    it('should return null on LLM error', async () => {
+      mockOpenAIClient.responses.create.mockRejectedValue(new Error('API Error'));
+
+      const summary = await service.synthesizeResults('test', mockResults);
+
+      expect(summary).toBeNull();
+    });
+
+    it('should return null for empty results', async () => {
+      const summary = await service.synthesizeResults('test', []);
+
+      expect(summary).toBeNull();
+      expect(mockOpenAIClient.responses.create).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/bot.js
+++ b/bot.js
@@ -27,6 +27,7 @@ const NickMappingService = require('./services/NickMappingService');
 const ChannelContextService = require('./services/ChannelContextService');
 const ImagePromptAnalyzerService = require('./services/ImagePromptAnalyzerService');
 const CatchMeUpService = require('./services/CatchMeUpService');
+const VoiceSearchService = require('./services/VoiceSearchService');
 const MongoService = require('./services/MongoService');
 const ImageRetryHandler = require('./handlers/ImageRetryHandler');
 const TextUtils = require('./utils/textUtils');
@@ -239,6 +240,15 @@ class DiscordBot {
     }
 
     // Initialize catch-me-up service
+    // Initialize voice-informed search (requires Qdrant + voice profile)
+    this.voiceSearchService = null;
+    if (this.qdrantService && this.voiceProfileService) {
+      this.voiceSearchService = new VoiceSearchService(
+        this.qdrantService, this.voiceProfileService, this.openaiClient, config
+      );
+      logger.info('Voice search service initialized');
+    }
+
     this.catchMeUpService = new CatchMeUpService(
       this.mongoService, this.voiceProfileService, this.openaiClient, config
     );
@@ -363,7 +373,7 @@ class DiscordBot {
 
     // Register IRC history slash commands
     if (this.qdrantService) {
-      this.slashCommandHandler.register(new RecallSlashCommand(this.qdrantService, this.nickMappingService));
+      this.slashCommandHandler.register(new RecallSlashCommand(this.qdrantService, this.nickMappingService, this.voiceSearchService));
       this.slashCommandHandler.register(new HistorySlashCommand(this.qdrantService, this.nickMappingService));
       this.slashCommandHandler.register(new ThrowbackSlashCommand(this.qdrantService));
       logger.info('IRC history slash commands registered');

--- a/commands/slash/RecallCommand.js
+++ b/commands/slash/RecallCommand.js
@@ -1,12 +1,12 @@
 // commands/slash/RecallCommand.js
-// Slash command for semantic search through IRC history
+// Slash command for semantic search through IRC history with optional voice-styled synthesis
 
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const BaseSlashCommand = require('../base/BaseSlashCommand');
 const logger = require('../../logger');
 
 class RecallSlashCommand extends BaseSlashCommand {
-  constructor(qdrantService, nickMappingService) {
+  constructor(qdrantService, nickMappingService, voiceSearchService = null) {
     super({
       data: new SlashCommandBuilder()
         .setName('recall')
@@ -16,6 +16,10 @@ class RecallSlashCommand extends BaseSlashCommand {
             .setDescription('What to search for')
             .setRequired(true)
             .setMaxLength(500))
+        .addBooleanOption(option =>
+          option.setName('summarize')
+            .setDescription('Get a voice-styled narrative summary instead of raw logs')
+            .setRequired(false))
         .addBooleanOption(option =>
           option.setName('my_messages')
             .setDescription('Only show your own messages')
@@ -32,16 +36,18 @@ class RecallSlashCommand extends BaseSlashCommand {
 
     this.qdrantService = qdrantService;
     this.nickMappingService = nickMappingService;
+    this.voiceSearchService = voiceSearchService;
   }
 
   async execute(interaction, context) {
     const query = interaction.options.getString('query');
+    const summarize = interaction.options.getBoolean('summarize') || false;
     const myMessages = interaction.options.getBoolean('my_messages') || false;
     const year = interaction.options.getInteger('year');
 
-    this.logExecution(interaction, `query="${query}", myMessages=${myMessages}, year=${year || 'any'}`);
+    this.logExecution(interaction, `query="${query}", summarize=${summarize}, myMessages=${myMessages}, year=${year || 'any'}`);
 
-    // Build search options object
+    // Build search options
     const searchOptions = { limit: 5 };
 
     if (year) {
@@ -49,7 +55,6 @@ class RecallSlashCommand extends BaseSlashCommand {
     }
 
     if (myMessages && this.nickMappingService) {
-      // Get user's IRC nicks
       const ircNicks = this.nickMappingService.getIrcNicks(interaction.user.id);
       if (ircNicks && ircNicks.length > 0) {
         searchOptions.participants = ircNicks;
@@ -62,8 +67,13 @@ class RecallSlashCommand extends BaseSlashCommand {
       }
     }
 
-    // Use correct signature: search(query, options)
-    const results = await this.qdrantService.search(query, searchOptions);
+    // Use voice-informed search (with query expansion) or plain search
+    let results;
+    if (this.voiceSearchService) {
+      results = await this.voiceSearchService.searchWithExpansion(query, searchOptions);
+    } else {
+      results = await this.qdrantService.search(query, searchOptions);
+    }
 
     if (!results || results.length === 0) {
       await this.sendReply(interaction, {
@@ -73,6 +83,22 @@ class RecallSlashCommand extends BaseSlashCommand {
       return;
     }
 
+    // Summarize mode: voice-styled narrative
+    if (summarize && this.voiceSearchService) {
+      const summary = await this.voiceSearchService.synthesizeResults(query, results);
+      if (summary) {
+        const chunks = this.splitMessage(summary, 2000);
+        await this.sendReply(interaction, chunks[0]);
+        for (let i = 1; i < chunks.length; i++) {
+          await interaction.followUp(chunks[i]);
+        }
+        return;
+      }
+      // Fall through to raw results if synthesis fails
+      logger.warn('Voice synthesis failed, falling back to raw results');
+    }
+
+    // Default: raw results as embed
     const embed = new EmbedBuilder()
       .setTitle(`IRC History Search`)
       .setDescription(`Results for: **${query}**${year ? ` (${year})` : ''}`)
@@ -86,7 +112,6 @@ class RecallSlashCommand extends BaseSlashCommand {
       const text = payload.text || payload.message || payload.content || 'No content';
       const score = result.score ? ` (${Math.round(result.score * 100)}% match)` : '';
 
-      // Format date like the service does
       let dateStr = '';
       if (payload.start_time) {
         try {

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -134,6 +134,7 @@ Use `/chatthread` to create a dedicated thread for extended conversations. In th
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `query` | Yes | Search terms |
+| `summarize` | No | Get a voice-styled narrative summary instead of raw logs |
 | `my_messages` | No | Only show your messages |
 | `year` | No | Filter by year (1999-2024) |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-article-archiver-bot",
-      "version": "2.11.1",
+      "version": "2.12.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "license": "MIT",
   "description": "A Discord bot that integrates with Linkwarden for self-hosted article archiving and uses OpenAI-compatible APIs to automatically generate summaries of archived articles with support for authenticated/paywalled content.",
   "main": "bot.js",

--- a/scripts/registerCommands.js
+++ b/scripts/registerCommands.js
@@ -79,7 +79,7 @@ async function registerCommands() {
   }
 
   if (config.qdrant?.enabled) {
-    commands.push(new RecallSlashCommand(null, null));
+    commands.push(new RecallSlashCommand(null, null, null));
     commands.push(new HistorySlashCommand(null, null));
     commands.push(new ThrowbackSlashCommand(null));
     console.log('Including IRC history commands (qdrant enabled)');

--- a/services/VoiceSearchService.js
+++ b/services/VoiceSearchService.js
@@ -1,0 +1,158 @@
+// services/VoiceSearchService.js
+// Voice-informed search: query expansion + voice-styled synthesis for IRC history
+
+const logger = require('../logger');
+
+class VoiceSearchService {
+  /**
+   * @param {Object} qdrantService - QdrantService for IRC history search
+   * @param {Object} voiceProfileService - VoiceProfileService for vocabulary and voice styling
+   * @param {Object} openaiClient - OpenAI client for LLM calls
+   * @param {Object} config - Bot configuration
+   */
+  constructor(qdrantService, voiceProfileService, openaiClient, config) {
+    this.qdrantService = qdrantService;
+    this.voiceProfileService = voiceProfileService;
+    this.openaiClient = openaiClient;
+    this.config = config;
+  }
+
+  /**
+   * Expand a search query using vocabulary from the voice profile
+   * @param {string} query - Original search query
+   * @returns {Promise<string[]>} Array of expanded query variants (includes original)
+   */
+  async expandQuery(query) {
+    try {
+      // Get vocabulary from voice profile
+      const profile = await this.voiceProfileService?.getProfile().catch(() => null);
+      const vocabulary = profile?.vocabulary || [];
+
+      const instruction = `You are a search query expander. Given a search query and a list of slang/vocabulary that a group of friends uses, generate 2-3 alternative phrasings of the query using their language.
+
+Return ONLY a JSON array of strings. Include variations using their vocabulary where relevant. Keep each variant under 50 characters.
+
+Example: query "server went down", vocabulary ["prod", "rip", "oof"]
+Output: ["prod went down", "server crashed rip", "server outage"]`;
+
+      const input = `Query: "${query}"${vocabulary.length > 0 ? `\nGroup vocabulary: ${vocabulary.join(', ')}` : ''}`;
+
+      const response = await this.openaiClient.responses.create({
+        model: this.config.openai.model || 'gpt-4.1-mini',
+        instructions: instruction,
+        input
+      });
+
+      let variants;
+      try {
+        // Parse JSON array from response, stripping any markdown fencing
+        const cleaned = response.output_text.replace(/```json?\n?|\n?```/g, '').trim();
+        variants = JSON.parse(cleaned);
+      } catch {
+        // If parsing fails, split by newlines
+        variants = response.output_text.split('\n').map(s => s.replace(/^[-*"\d.]+\s*/, '').trim()).filter(Boolean);
+      }
+
+      // Always include the original query
+      if (!variants.includes(query)) {
+        variants.unshift(query);
+      }
+
+      logger.info(`Query expansion: "${query}" → [${variants.join(', ')}]`);
+      return variants;
+
+    } catch (error) {
+      logger.error(`Query expansion failed: ${error.message}`);
+      return [query];
+    }
+  }
+
+  /**
+   * Search with expanded queries, merge and deduplicate results
+   * @param {string} query - Original search query
+   * @param {Object} searchOptions - Qdrant search options (year, participants, etc.)
+   * @returns {Promise<Array>} Deduplicated, score-sorted results
+   */
+  async searchWithExpansion(query, searchOptions) {
+    const expandedQueries = await this.expandQuery(query);
+
+    // Search all variants in parallel
+    const searchPromises = expandedQueries.map(q =>
+      this.qdrantService.search(q, { ...searchOptions, limit: 5 })
+        .catch(err => {
+          logger.debug(`Search failed for variant "${q}": ${err.message}`);
+          return [];
+        })
+    );
+
+    const allResults = await Promise.all(searchPromises);
+
+    // Merge and deduplicate by point ID, keeping highest score
+    const deduped = new Map();
+    for (const results of allResults) {
+      for (const result of results) {
+        const existing = deduped.get(result.id);
+        if (!existing || result.score > existing.score) {
+          deduped.set(result.id, result);
+        }
+      }
+    }
+
+    // Sort by score descending
+    const merged = Array.from(deduped.values()).sort((a, b) => b.score - a.score);
+
+    logger.info(`Voice search: ${expandedQueries.length} queries → ${allResults.flat().length} raw results → ${merged.length} deduplicated`);
+    return merged.slice(0, searchOptions.limit || 5);
+  }
+
+  /**
+   * Synthesize search results into a voice-styled narrative summary
+   * @param {string} query - Original search query
+   * @param {Array} results - Qdrant search results
+   * @returns {Promise<string|null>} Voice-styled summary or null on error
+   */
+  async synthesizeResults(query, results) {
+    if (!results || results.length === 0) return null;
+
+    try {
+      const profile = await this.voiceProfileService?.getProfile().catch(() => null);
+
+      // Build compact context from results
+      const resultsContext = results.map(r => {
+        const p = r.payload;
+        const date = p.start_time ? new Date(p.start_time).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : (p.year || '');
+        return `[${date} - ${p.channel || ''}]\n${p.text}`;
+      }).join('\n\n');
+
+      let instruction = `You are summarizing IRC conversation search results for a user who asked: "${query}"
+
+RULES:
+- ONLY reference content that appears in the provided conversation logs
+- Synthesize the results into a brief, natural narrative (2-4 sentences)
+- Mention who said what and when
+- Do NOT invent details not present in the logs`;
+
+      if (profile) {
+        instruction += `\n\nStyle your response to match this group's communication style:\n${profile.voiceInstructions || ''}`;
+        if (profile.toneKeywords?.length > 0) {
+          instruction += `\nTone: ${profile.toneKeywords.join(', ')}`;
+        }
+      }
+
+      const response = await this.openaiClient.responses.create({
+        model: this.config.openai.model || 'gpt-4.1-mini',
+        instructions: instruction,
+        input: resultsContext
+      });
+
+      logger.info(`Voice synthesis: ${response.usage?.input_tokens || 0} input, ${response.usage?.output_tokens || 0} output tokens`);
+      return response.output_text.trim();
+
+    } catch (error) {
+      logger.error(`Voice synthesis failed: ${error.message}`);
+      return null;
+    }
+  }
+}
+
+module.exports = VoiceSearchService;


### PR DESCRIPTION
## Summary
Level 4 RAG pipeline for `/recall` using the channel voice profile:

1. **Query Understanding** — LLM expands search query using group vocabulary (e.g., "kubernetes outage" → ["k8s outage", "kube stuff broke"])
2. **Parallel Search** — expanded queries run against Qdrant simultaneously, results merged and deduplicated by point ID (highest score wins)  
3. **Voice Synthesis** — optional `summarize:true` flag passes results through LLM with voice profile for a natural narrative summary

**Always-on improvement:** Query expansion runs on every `/recall` when VoiceSearchService is available. Raw log results remain the default — `summarize:true` is opt-in.

**Performance:** Both LLM calls use minimal context (~2K tokens total vs 6K for /chat). Estimated 4-7s total latency.

## New components
- `VoiceSearchService` — expandQuery, searchWithExpansion, synthesizeResults
- `/recall` gains `summarize` boolean option

## Test plan
- [x] 13 tests for VoiceSearchService (expansion, dedup, synthesis, error handling)
- [x] Full suite passes (696 tests, 25 suites)
- [x] Deployed to k8s as v2.12.0
- [x] Commands registered globally
- [ ] Test `/recall query:"topic" summarize:true` in Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)