### PR TITLE
fix: route unhandled bot-message replies to mention chat + drop personality header

### DIFF
--- a/__tests__/handlers/ReplyHandler.test.js
+++ b/__tests__/handlers/ReplyHandler.test.js
@@ -182,6 +182,14 @@ describe('ReplyHandler', () => {
 
       expect(result).toBe(false);
     });
+
+    it('should return false for channel-voice / personality-formatted bot replies (handled by mention-chat fall-through in bot.js)', async () => {
+      mockReferencedMessage.content = '🗣️ **Channel Voice**\n\nHey, what\'s up? Glad you asked.';
+
+      const result = await replyHandler.handleReply(mockMessage, mockReferencedMessage);
+
+      expect(result).toBe(false);
+    });
   });
 
   describe('handleSummarizationReply', () => {

--- a/bot.js
+++ b/bot.js
@@ -667,13 +667,11 @@ class DiscordBot {
         });
       }
 
-      // Format response with personality header and wrap URLs
+      // Format response and wrap URLs (no personality header \u2014 channel-voice is the only personality)
       const fallbackNotice = result.fallback?.occurred
-        ? `\n> *\u26A0\uFE0F Local LLM unavailable \u2014 responded using ${result.personality.emoji} ${result.personality.name} instead*\n`
+        ? `> *\u26A0\uFE0F Local LLM unavailable \u2014 responded with cloud fallback instead*\n\n`
         : '';
-      const response = TextUtils.wrapUrls(
-        `${result.personality.emoji} **${result.personality.name}**${fallbackNotice}\n\n${result.message}`
-      );
+      const response = TextUtils.wrapUrls(`${fallbackNotice}${result.message}`);
 
       // Convert any generated images to Discord attachments
       const imageAttachments = this._createImageAttachments(result.images);

--- a/bot.js
+++ b/bot.js
@@ -518,16 +518,22 @@ class DiscordBot {
           const referencedMessage = await message.channel.messages.fetch(message.reference.messageId);
           if (referencedMessage && referencedMessage.author.id === this.client.user.id) {
             // Wrap reply handling in a trace
-            await withRootSpan('discord.reply', {
+            const handled = await withRootSpan('discord.reply', {
               'discord.channel.id': message.channel.id,
               'discord.user.id': message.author.id,
               'discord.user.tag': message.author.tag,
               'discord.message.id': message.id,
             }, async () => {
-              const handled = await this.replyHandler.handleReply(message, referencedMessage);
-              return handled;
+              return await this.replyHandler.handleReply(message, referencedMessage);
             });
-            return; // Reply was handled, don't process as command
+
+            if (handled) {
+              return;
+            }
+            // ReplyHandler didn't claim this (not summarization, not imagegen).
+            // Fall through to mention-chat so the bot continues the conversation.
+            await this._handleMentionChat(message);
+            return;
           }
         } catch (error) {
           logger.error(`Error fetching referenced message: ${error.message}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-article-archiver-bot",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-article-archiver-bot",
-      "version": "2.12.1",
+      "version": "2.12.2",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "license": "MIT",
   "description": "A Discord bot that integrates with Linkwarden for self-hosted article archiving and uses OpenAI-compatible APIs to automatically generate summaries of archived articles with support for authenticated/paywalled content.",
   "main": "bot.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "license": "MIT",
   "description": "A Discord bot that integrates with Linkwarden for self-hosted article archiving and uses OpenAI-compatible APIs to automatically generate summaries of archived articles with support for authenticated/paywalled content.",
   "main": "bot.js",


### PR DESCRIPTION
## Summary

- **Fix dropped replies (v2.12.1):** Replies to `channel-voice` / mention-chat bot messages were silently dropped. `ReplyHandler.handleReply()` only matches summarization and imagegen patterns; everything else returns `false`. `bot.js` was wrapping that call in `withRootSpan` and unconditionally `return`ing out of `messageCreate`, ignoring the boolean. Imagegen replies kept working because they still match `isImageGenerationMessage`. Capture the return value and, on `false`, fall through to `_handleMentionChat` so the bot continues the conversation under the existing chat flow.
- **Drop personality header from chat responses (v2.12.2):** `channel-voice` is the only personality (per v2.8.x simplification). The `🗣️ **Channel Voice**` header on every mention-chat / reply response is noise — `/chat` slash command already omits it. Remove the emoji+name header and rephrase the local-LLM fallback notice to no longer reference personality fields.

## Root cause of the dropped replies

Commit `ccd8fd0` ("chore: remove dead personality detection and routing code", 2026-04-10, shipped in v2.8.2) deleted `detectPersonalityFromMessage()` / `handlePersonalityChatReply()`. That code wasn't actually dead — `_handleMentionChat` in `bot.js` still emits `${emoji} **${name}**\n\n${message}`, the exact pattern the deleted detector matched. `features.md` lines 58, 111, 112, 123 all document "Reply to bot messages to continue conversations" as supported behavior.

## Test plan

- [x] Added regression-guard test: `handleReply` returns `false` for channel-voice formatted bot content.
- [x] Full test suite passes (697 tests, 25 suites).
- [x] Deployed v2.12.2 to k8s `discord-article-bot` namespace; pod healthy, bot online.
- [ ] Functional test in Discord: reply (Discord reply feature) to a bot mention-chat message → bot continues the conversation, no `🗣️ Channel Voice` header.
- [ ] Functional test: reply to bot summarization → still gets follow-up answer.
- [ ] Functional test: reply to bot imagegen → still regenerates with feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)