### PR TITLE
fix: /musicgen string-option limits raised to Discord max (6000)

### DIFF
--- a/commands/slash/MusicgenCommand.js
+++ b/commands/slash/MusicgenCommand.js
@@ -14,9 +14,9 @@ class MusicgenSlashCommand extends BaseSlashCommand {
       data: new SlashCommandBuilder()
         .setName('musicgen')
         .setDescription('Generate music with Lyria 3')
-        .addStringOption((o) => o.setName('prompt').setDescription('What to generate').setRequired(true).setMaxLength(1000))
-        .addStringOption((o) => o.setName('lyrics').setDescription('Custom lyrics. Supports [Verse] / [Chorus] / [Bridge] tags').setRequired(false).setMaxLength(2000))
-        .addStringOption((o) => o.setName('negative_prompt').setDescription('Things to avoid (e.g. "no vocals", "no drums")').setRequired(false).setMaxLength(500))
+        .addStringOption((o) => o.setName('prompt').setDescription('What to generate').setRequired(true).setMaxLength(6000))
+        .addStringOption((o) => o.setName('lyrics').setDescription('Custom lyrics. Supports [Verse] / [Chorus] / [Bridge] tags').setRequired(false).setMaxLength(6000))
+        .addStringOption((o) => o.setName('negative_prompt').setDescription('Things to avoid (e.g. "no vocals", "no drums")').setRequired(false).setMaxLength(6000))
         .addAttachmentOption((o) => o.setName('image1').setDescription('Reference image 1').setRequired(false))
         .addAttachmentOption((o) => o.setName('image2').setDescription('Reference image 2').setRequired(false))
         .addAttachmentOption((o) => o.setName('image3').setDescription('Reference image 3').setRequired(false)),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-article-archiver-bot",
-      "version": "2.14.1",
+      "version": "2.14.2",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-article-archiver-bot",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "license": "MIT",
   "description": "A Discord bot that integrates with Linkwarden for self-hosted article archiving and uses OpenAI-compatible APIs to automatically generate summaries of archived articles with support for authenticated/paywalled content.",
   "main": "bot.js",


### PR DESCRIPTION
## Summary
Raises `/musicgen` `prompt`, `lyrics`, and `negative_prompt` `max_length` from `1000`/`2000`/`500` to **`6000`** — Discord's actual hard cap for slash-command string options.

## Why
The original Task 8 values were conservative project-side limits, not Discord's. Users hit the 1000-char ceiling on longer prompts and the 2000-char ceiling on full sets of lyrics. The Lyria 3 Pro API has no documented length restriction worth respecting before Discord's own — push the bound out to where the platform stops you.

## Test plan
- [x] `npm test` — 746/746 green
- [x] Schema introspection: `c.data.toJSON().options[].max_length` all read 6000 for the three string options
- [x] Image `mvilliger/discord-article-bot:31b8eea` built and rolled out to `discord-article-bot` namespace
- [x] **`scripts/registerCommands.js` re-run inside the new pod** — Discord stores the schema at registration time, so the new limits would not take effect on the client without this step. 20 commands registered including `/musicgen`.
- [ ] Manual smoke test in Discord — try a long prompt and a long lyrics block to confirm the input field accepts them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)