### PR TITLE
fix(scripts): registerCommands.js — register globally AND to test guild

### DIFF
--- a/scripts/registerCommands.js
+++ b/scripts/registerCommands.js
@@ -101,32 +101,31 @@ async function registerCommands() {
   const rest = new REST({ version: '10' }).setToken(config.discord.token);
 
   try {
-    // Check if we should register to a specific guild (instant) or globally (up to 1 hour)
-    const testGuildId = config.discord.testGuildId;
+    // Always register globally so commands appear in every guild the bot is in.
+    // Global commands can take up to 1 hour to propagate to Discord clients.
+    console.log('\nRegistering globally (may take up to 1 hour to propagate to all guilds)...');
 
+    await rest.put(
+      Routes.applicationCommands(config.discord.clientId),
+      { body: commandData }
+    );
+
+    console.log(`Successfully registered ${commandData.length} global commands`);
+
+    // If a test guild is configured, ALSO register there for instant feedback
+    // during development. Guild commands shadow global ones in that guild, so
+    // there's no duplication or conflict.
+    const testGuildId = config.discord.testGuildId;
     if (testGuildId) {
-      // Guild-specific registration (instant updates, good for development)
-      console.log(`\nRegistering to guild ${testGuildId} (instant)...`);
+      console.log(`\nAlso registering to test guild ${testGuildId} (instant)...`);
 
       await rest.put(
         Routes.applicationGuildCommands(config.discord.clientId, testGuildId),
         { body: commandData }
       );
 
-      console.log(`Successfully registered ${commandData.length} commands to guild ${testGuildId}`);
-      console.log('\nNote: Guild commands update instantly.');
-
-    } else {
-      // Global registration (can take up to 1 hour to propagate)
-      console.log('\nRegistering globally (may take up to 1 hour to propagate)...');
-
-      await rest.put(
-        Routes.applicationCommands(config.discord.clientId),
-        { body: commandData }
-      );
-
-      console.log(`Successfully registered ${commandData.length} global commands`);
-      console.log('\nNote: Global commands can take up to 1 hour to appear in all servers.');
+      console.log(`Successfully registered ${commandData.length} commands to test guild ${testGuildId}`);
+      console.log('Note: Guild commands update instantly and override the global definitions in that guild.');
     }
 
     console.log('\nDone!');


### PR DESCRIPTION
## Summary
Bring main in sync with what's already in production (image `b42990d`, deployed during PR #77's execution).

`scripts/registerCommands.js` was either/or: if `DISCORD_TEST_GUILD_ID` was set in the configmap (it is), the script registered ONLY to that guild. Every other guild the bot is in kept stale global command definitions forever because we never pushed globally. That's why the `/musicgen` limit bump in PR #77 wasn't visible outside the test guild until I re-ran the patched script.

## Why this is a separate PR
The fix was committed on the PR #77 branch (`fix/musicgen-character-limits`) at `887559c` + `b42990d`, but PR #77 was merged before those commits could be folded into it. The fix lives in the running pod (we deployed `b42990d`) but never reached `main`. This PR restores parity.

## What the fix does
- Always pushes commands globally first (propagates to every guild the bot is in, ≤1 hour Discord-side cache).
- If `DISCORD_TEST_GUILD_ID` is set, *also* pushes to that guild for instant feedback. Discord shadows globals with guild commands in that guild, so no duplication.

## Test plan
- [x] Production pod already running the fixed version (`b42990d`)
- [x] Already re-registered: log output showed both `Successfully registered 20 global commands` and `Successfully registered 20 commands to test guild 575690974190239744`
- [x] Schema verified: `/musicgen` `max_length: 6000` on all three string options
- [ ] No further deploy needed for this PR — it's purely a source-of-truth sync. Any future deploy from main would have lost the fix without this.

## No version bump
The version on main is `2.14.2`. Production is on the same code as `2.14.3` would be, but since this PR has no behavior change relative to the deployed code, no bump is added. The next behavior change (next mem0 / @google/genai / OTEL PR) will bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)