### PR TITLE
fix(agent): exponential backoff on transient Gemini 503s

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,8 @@ When `AGENT_ENABLED=true`, channel-voice chats are routed through the Python age
 
 **Toggle:** `AGENT_ENABLED=false` reverts channel-voice to direct OpenAI immediately. The `AgentClient` health-polls every 5s and considers the sidecar unhealthy after 30s without a successful Health response, falling through to direct OpenAI when the sidecar is gone.
 
+**Transient 503 handling:** the Gemini-native path attaches SDK-level exponential backoff (`agent.py` `_gemini_retry_options`: 4 attempts, 0.5→8s, jitter, on `429/500/502/503/504`). New preview models (e.g. `gemini-3.5-flash`) spike 503 "model overloaded" errors; without this each one immediately fell through to the `gpt-5-mini` fallback, silently swapping the model. Retry is at the HTTP-call layer, NOT the agent turn, so sandbox tools are never re-executed. The bot's `AgentClient` chat deadline (600s) comfortably exceeds the ~8s retry budget.
+
 **Sidecar:** single-replica `Recreate` Deployment — concurrency state is in-process; **do not scale**.
 
 **Tunables (sandbox-config ConfigMap):** `SANDBOX_INLINE_OUTPUT_CHARS`, `SANDBOX_WALL_CLOCK_SECONDS`, `SANDBOX_PER_USER_CONCURRENCY`, `SANDBOX_GLOBAL_CONCURRENCY`, `SANDBOX_MEMORY_LIMIT`, `SANDBOX_CPU_LIMIT`, `SANDBOX_BASE_IMAGE`, `SANDBOX_TRACE_RETENTION_PER_USER`, `SANDBOX_AGENT_TURN_CALL_BUDGET`.

--- a/agent-sidecar/src/agent.py
+++ b/agent-sidecar/src/agent.py
@@ -9,6 +9,7 @@ import logging
 from dataclasses import dataclass
 
 from google.adk.agents import Agent
+from google.adk.models import Gemini
 from google.adk.runners import InMemoryRunner
 from google.genai import types
 
@@ -93,22 +94,48 @@ def _build_generate_content_config():
     )
 
 
+def _gemini_retry_options():
+    """SDK-level exponential backoff for the Gemini-native path.
+
+    google-genai does NOT retry transient server errors by default, so a
+    single 503 "model is currently experiencing high demand" surfaces as an
+    AgentLLMError and the bot immediately falls through to the OpenAI
+    fallback — silently swapping the model out from under the user. New
+    preview models (e.g. gemini-3.5-flash) spike 503s frequently, so we
+    retry the failing HTTP call here (NOT the whole agent turn — retrying the
+    turn could re-execute sandbox tools). Last resort after exhausting these
+    attempts is still the bot's OpenAI fallback.
+
+    Budget: 0.5s, 1s, 2s, 4s (+jitter) ≈ up to ~8s before giving up. The
+    bot's AgentClient gRPC deadline must exceed this (see AgentClient.js).
+    """
+    return types.HttpRetryOptions(
+        attempts=4,
+        initial_delay=0.5,
+        max_delay=8.0,
+        exp_base=2.0,
+        jitter=0.3,
+        http_status_codes=[429, 500, 502, 503, 504],
+    )
+
+
 def _build_model(model_spec: str):
     """Map an `AGENT_MODEL` env value to whatever ADK's `Agent(model=…)`
-    expects. For Gemini we pass a bare string (ADK auto-selects the native
-    Google genai client); for any other provider we wrap in LiteLlm.
+    expects. For Gemini we return a `Gemini` model wired with SDK-level
+    retry (see _gemini_retry_options); for any other provider we wrap in
+    LiteLlm.
 
     Accepted shapes:
-      "gemini-3-flash-preview"              -> "gemini-3-flash-preview"          (native)
-      "gemini/gemini-3-flash"       -> "gemini-3-flash-preview"          (native)
+      "gemini-3-flash-preview"      -> Gemini("gemini-3-flash-preview", retry)  (native)
+      "gemini/gemini-3-flash"       -> Gemini("gemini-3-flash", retry)          (native)
       "openai/gpt-5.1"              -> LiteLlm("openai/gpt-5.1")
       "anthropic/claude-opus-4-7"   -> LiteLlm("anthropic/...")
     """
     spec = (model_spec or "").strip() or "gemini-3-flash-preview"
     if spec.startswith("gemini/"):
-        return spec[len("gemini/"):]
+        spec = spec[len("gemini/"):]
     if spec.startswith("gemini") or "/" not in spec:
-        return spec
+        return Gemini(model=spec, retry_options=_gemini_retry_options())
     # Non-Gemini providers go through LiteLlm. Imported lazily so we don't
     # require the litellm dependency just to run the default Gemini path.
     from google.adk.models.lite_llm import LiteLlm

--- a/agent-sidecar/tests/test_agent_model.py
+++ b/agent-sidecar/tests/test_agent_model.py
@@ -3,22 +3,42 @@ AGENT_MODEL string and what ADK's Agent(model=…) actually expects."""
 from src.agent import _build_model
 
 
-def test_native_gemini_returns_string():
-    assert _build_model("gemini-3-flash-preview") == "gemini-3-flash-preview"
+def test_native_gemini_returns_gemini_model():
+    assert _build_model("gemini-3-flash-preview").model == "gemini-3-flash-preview"
 
 
 def test_gemini_prefix_stripped():
-    assert _build_model("gemini/gemini-3-flash-preview") == "gemini-3-flash-preview"
+    assert _build_model("gemini/gemini-3-flash-preview").model == "gemini-3-flash-preview"
 
 
 def test_empty_falls_back_to_default():
-    assert _build_model("") == "gemini-3-flash-preview"
-    assert _build_model("   ") == "gemini-3-flash-preview"
+    assert _build_model("").model == "gemini-3-flash-preview"
+    assert _build_model("   ").model == "gemini-3-flash-preview"
 
 
 def test_bare_model_with_no_slash_treated_as_native():
     # A bare model name (no provider prefix) is assumed Gemini-native.
-    assert _build_model("gemini-3.1-flash-lite-preview") == "gemini-3.1-flash-lite-preview"
+    assert _build_model("gemini-3.1-flash-lite-preview").model == "gemini-3.1-flash-lite-preview"
+
+
+def test_native_gemini_configures_exponential_retry_on_503():
+    # Gemini-native path must attach SDK-level retry so transient 503
+    # "model overloaded" spikes are absorbed before the bot falls through
+    # to the OpenAI fallback.
+    m = _build_model("gemini-3.5-flash")
+    assert getattr(m, "model", None) == "gemini-3.5-flash"
+    ro = m.retry_options
+    assert ro is not None
+    assert 503 in ro.http_status_codes
+    assert 429 in ro.http_status_codes
+    assert ro.attempts >= 3
+    assert ro.exp_base > 1  # exponential, not linear
+
+
+def test_litellm_path_has_no_genai_retry_options():
+    # Non-Gemini providers go through LiteLlm, which has no genai retry_options.
+    m = _build_model("openai/gpt-5.1")
+    assert not hasattr(m, "retry_options")
 
 
 def test_openai_uses_litellm_wrapper():


### PR DESCRIPTION
## Problem

The Gemini-native path in the agent sidecar returned a bare model **string** with no retry config. google-genai does not retry transient server errors by default, so a single `503 UNAVAILABLE` ("model is currently experiencing high demand") surfaced as an `AgentLLMError` and the bot **immediately fell through to the `gpt-5-mini` fallback** — silently swapping the model out from under the user.

New preview models like `gemini-3.5-flash` spike these 503s frequently (observed ~9 in a 2h window, each correlated with a `falling through to direct-OpenAI` in the bot log), so channel-voice was often *not* actually being served by the configured model.

## Fix

`_build_model()` now returns a `Gemini` model wired with SDK-level `HttpRetryOptions`:
- **4 attempts**, `0.5 → 8s` exponential backoff (`exp_base=2.0`) with jitter
- retries on `429, 500, 502, 503, 504`

Retry is at the **HTTP-call layer, not the agent turn**, so sandbox tools are never re-executed. The bot's `AgentClient` chat deadline (600s) already exceeds the ~8s retry budget, so no client change was needed.

## Tests (TDD)

- New: native path attaches exponential 503/429 retry; LiteLlm path has no genai retry_options
- Updated the 4 existing `_build_model` contract tests (string → `Gemini` object via `.model`)
- **64/64 agent-sidecar tests pass**

## Verification

Deployed as `e64f527` (agent image + `sandbox-base` re-tagged in lockstep). Exec'd the live pod: `_build_model('gemini-3.5-flash').retry_options` → `attempts=4, codes=[429,500,502,503,504], 503 retried: True`. Zero fallthroughs since rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)