### PR TITLE
fix(voice): multi-stage bot Dockerfile (trixie) for native voice deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,39 @@
-# @discordjs/voice ^0.19.0 requires Node >=22.12 (node:22-slim satisfies this).
-# NOTE: Debian slim (glibc), NOT Alpine (musl): onnxruntime-node (openWakeWord
-# wake-word engine) ships glibc-only prebuilt binaries and fails to load on musl.
-FROM node:22-slim
+# Multi-stage build.
+# @discordjs/voice ^0.19.0 requires Node >=22.12. Debian bookworm (glibc), NOT
+# Alpine (musl): onnxruntime-node (openWakeWord wake-word engine) ships glibc-only
+# prebuilt binaries and fails to load on musl.
+#
+# The native voice deps (@discordjs/opus) compile from source when no prebuilt
+# binary matches the Node ABI, so the builder stage uses the full `node:22` image
+# (includes python3/make/g++ via buildpack-deps). The runtime stage is `node:22-slim`
+# — same bookworm glibc, so the compiled .node addons and onnxruntime's .so are
+# ABI/glibc-compatible — kept lean by copying only the built node_modules.
 
+# ---- builder: has the toolchain to compile native modules ----
+# Pin BOTH stages to the SAME Debian codename (trixie) so the builder and runtime
+# glibc match. Trixie (glibc >=2.39) is required at runtime because some deps ship
+# prebuilt binaries built against glibc 2.38 (e.g. sqlite3 via node-pre-gyp) that
+# crash on bookworm-slim's 2.36 ("GLIBC_2.38 not found"). trixie full =
+# buildpack-deps (python3/make/g++ to compile @discordjs/opus); trixie-slim runtime
+# = matching glibc, kept lean by copying only the built node_modules.
+FROM node:22-trixie AS builder
 WORKDIR /usr/src/app
-
-# Copy package files and install dependencies
 COPY package*.json ./
 RUN npm ci --only=production
-
 # Prune onnxruntime-node's unused GPU execution providers (~252 MB): the bot runs
-# wake-word inference CPU-only, but the package bundles a ~251 MB CUDA provider
-# and a TensorRT shim. Removing them keeps the CPU provider (in libonnxruntime.so)
-# and the binding loadable; only the mel/embedding/wake models run here.
+# wake-word inference CPU-only, but the package bundles a ~251 MB CUDA provider and
+# a TensorRT shim. Removing them keeps the CPU provider (in libonnxruntime.so) and
+# the binding loadable; only the mel/embedding/wake models run here.
 RUN rm -f node_modules/onnxruntime-node/bin/napi-v*/linux/*/libonnxruntime_providers_cuda.so \
           node_modules/onnxruntime-node/bin/napi-v*/linux/*/libonnxruntime_providers_tensorrt.so
 
-# Copy application code
+# ---- runtime: slim (trixie, glibc matches the builder) ----
+FROM node:22-trixie-slim
+WORKDIR /usr/src/app
+# App code first (node_modules is .dockerignore'd, so this won't clobber the copy below).
 COPY . .
+# Compiled + pruned dependencies from the builder.
+COPY --from=builder /usr/src/app/node_modules ./node_modules
 
 # Change ownership to node user (uid 1000) for security
 RUN chown -R node:node /usr/src/app


### PR DESCRIPTION
## Fix: multi-stage bot Dockerfile so the voice native deps build + load

The voice feature added native Node modules (`@discordjs/opus`, `sodium-native`, `onnxruntime-node`) and bumped the bot image to `node:22-slim`, but that image **fails to build and fails to run**:

1. **Build:** `node:22-slim` has no compiler, so `@discordjs/opus`'s node-pre-gyp source build fails (`npm ci` exit 1).
2. **Run:** even once it builds, `sqlite3` installs a **prebuilt** binary compiled against **glibc 2.38**, which crashes on bookworm-slim's 2.36 (`GLIBC_2.38 not found`) → CrashLoopBackOff.

### Fix
Multi-stage, both stages pinned to **trixie** (same codename → matching glibc, and glibc ≥2.39 satisfies the prebuilts):
- **Builder `node:22-trixie`** (buildpack-deps: python3/make/g++) compiles `@discordjs/opus` and installs prod deps, then prunes onnxruntime-node's unused ~252 MB CUDA/TensorRT providers.
- **Runtime `node:22-trixie-slim`** copies the built `node_modules` in — lean runtime, matching glibc.

### Verified
- Local **native-load pre-flight** passes: `sqlite3`, `onnxruntime-node`, `@discordjs/opus`, `sodium-native`, `@discordjs/voice`, `prism-media` all `require()` cleanly under the runtime image.
- **Deployed live** (image `ee33cf3`): bot Running 1/1, `VoiceClient health OK` to the voice sidecar, `/voice` registered.

> Note: discovered during the live voice rollout — the bot briefly crash-looped on the first (single-stage) attempt and was rolled back to the prior image within ~1 min; this is the fix-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
